### PR TITLE
Feature/navbar realtime badges

### DIFF
--- a/backend/src/controllers/chat.controller.ts
+++ b/backend/src/controllers/chat.controller.ts
@@ -138,3 +138,15 @@ export const getConversation = async (req: AuthenticatedRequest, res: Response) 
         return res.status(500).json({ error: error instanceof Error ? error.message : 'Server error' });
     }
 };
+
+export const getUnreadCount = async (req: AuthenticatedRequest, res: Response) => {
+    try {
+        if (!req.user) {
+            throw new Error('Authentication required');
+        }
+        const total = await chatService.getTotalUnreadCount(req.user.userId);
+        return res.status(200).json({ count: total });
+    } catch (error) {
+        return res.status(500).json({ error: error instanceof Error ? error.message : 'Server error' });
+    }
+};

--- a/backend/src/events/notification.emitter.ts
+++ b/backend/src/events/notification.emitter.ts
@@ -1,0 +1,3 @@
+import { EventEmitter } from "events";
+
+export const notificationEmitter = new EventEmitter();

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -14,6 +14,7 @@ import geocodingRoutes from './routes/geocoding.routes.js';
 import notificationRoutes from './routes/notification.routes.js'
 import conversationRoutes from './routes/conversation.routes.js';
 import { setupChatSocket } from './socket/chat.handlers.js';
+import { setupNotificationSocket } from './socket/notification.handlers.js';
 
 const app = express();
 const port = process.env.PORT_BACKEND || 4000;
@@ -43,6 +44,7 @@ const io = new SocketServer(server, {
 });
 
 setupChatSocket(io);
+setupNotificationSocket(io);
 
 // --- START DB THEN SERVER ---
 console.log("🟡 Initializing database...");

--- a/backend/src/repositories/conversation.repository.ts
+++ b/backend/src/repositories/conversation.repository.ts
@@ -115,4 +115,17 @@ export const conversationRepository = {
     const res = await pool.query(query, [userId, conversationId]);
     return res.rows[0];
   },
+
+  getTotalUnreadCount: async (userId: number): Promise<number> => {
+    const query = `
+      SELECT COUNT(*)::int AS total
+      FROM messages m
+      JOIN conversations c ON c.id = m.conversation_id
+      WHERE (c.user1_id = $1 OR c.user2_id = $1)
+        AND m.sender_id != $1
+        AND m.is_read = false
+    `;
+    const res = await pool.query(query, [userId]);
+    return res.rows[0]?.total ?? 0;
+  },
 };

--- a/backend/src/routes/conversation.routes.ts
+++ b/backend/src/routes/conversation.routes.ts
@@ -1,10 +1,11 @@
 import { Router } from 'express';
-import { getConversations, getConversation, getMessages, createConversation, sendMessage } from '../controllers/chat.controller.js';
+import { getConversations, getConversation, getMessages, createConversation, sendMessage, getUnreadCount } from '../controllers/chat.controller.js';
 import { authenticateToken } from '../middleware/auth.middleware.js';
 
 const router = Router();
 
 router.get('/', authenticateToken, getConversations);
+router.get('/unread-count', authenticateToken, getUnreadCount)
 router.get('/:id', authenticateToken, getConversation);
 router.get('/:id/messages', authenticateToken, getMessages);
 router.post('/', authenticateToken, createConversation);

--- a/backend/src/services/chat.service.ts
+++ b/backend/src/services/chat.service.ts
@@ -146,4 +146,8 @@ export const chatService = {
         }
         return message;
     },
+
+    getTotalUnreadCount: async (userId: number): Promise<number> => {
+        return conversationRepository.getTotalUnreadCount(userId);
+    },
 };

--- a/backend/src/services/notification.service.ts
+++ b/backend/src/services/notification.service.ts
@@ -1,4 +1,5 @@
 import { notificationRepository } from "../repositories/notification.repository.js";
+import { notificationEmitter } from "../events/notification.emitter.js";
 import type { NotificationType } from "../types/notification.types.js";
 
 export const notificationService = {
@@ -6,7 +7,11 @@ export const notificationService = {
         return await notificationRepository.getNotifications(userId);
     },
     createNotification: async (userId: number, actorId: number, type: NotificationType, referenceId?: number) => {
-        return notificationRepository.createNotifiation(userId, actorId, type, referenceId);
+        const notification = await notificationRepository.createNotifiation(userId, actorId, type, referenceId);
+        if (notification) {
+            notificationEmitter.emit('notification:created', { userId });
+        }
+        return notification;
     },
     markAsRead: async (notificationId: number, userId: number) => {
         return notificationRepository.markAsRead(notificationId, userId);

--- a/backend/src/socket/chat.handlers.ts
+++ b/backend/src/socket/chat.handlers.ts
@@ -24,6 +24,15 @@ export function setupChatSocket(io: Server): void {
         console.log("🔌 User connected:", socket.id, "userId:", userId);
         socket.join(`user:${userId}`);
 
+        const emitUnreadCount = async (targetUserId: number) => {
+            try {
+                const total = await conversationRepository.getTotalUnreadCount(targetUserId);
+                io.to(`user:${targetUserId}`).emit('unreadMessageCount', { count: total });
+            } catch (err) {
+                console.error('Failed to emit unreadMessageCount:', err);
+            }
+        };
+
         const emitConversationUpdated = async (conversationId: number) => {
             const conversation = await conversationRepository.getConversationById(conversationId);
             if (!conversation) return;
@@ -32,6 +41,7 @@ export function setupChatSocket(io: Server): void {
                 try {
                     const summary = await chatService.getConversationSummary(conversationId, participantId);
                     io.to(`user:${participantId}`).emit('conversationUpdated', summary);
+                    await emitUnreadCount(participantId);
                 } catch (err) {
                     console.error('Failed to emit conversationUpdated:', err);
                 }
@@ -43,6 +53,7 @@ export function setupChatSocket(io: Server): void {
             for (const conv of conversations) {
                 socket.join(`conversation:${conv.id}`)
             }
+            await emitUnreadCount(userId);
         } catch (err) {
             console.error('Failed to auto-join conversations:', err);
         }
@@ -63,6 +74,7 @@ export function setupChatSocket(io: Server): void {
                 const summary = await chatService.markConversationRead(conversationId, userId);
                 socket.join(`conversation:${conversationId}`);
                 io.to(`user:${userId}`).emit('conversationUpdated', summary);
+                await emitUnreadCount(userId);
                 cb?.({ ok: true, conversation: summary });
             } catch (err) {
                 cb?.({ error: err instanceof Error ? err.message : 'Failed to join' });
@@ -82,6 +94,7 @@ export function setupChatSocket(io: Server): void {
                 }
                 const summary = await chatService.markConversationRead(conversationId, userId);
                 io.to(`user:${userId}`).emit('conversationUpdated', summary);
+                await emitUnreadCount(userId);
                 cb?.({ ok: true });
             } catch (err) {
                 cb?.({ error: err instanceof Error ? err.message : 'Failed to mark as read' });

--- a/backend/src/socket/notification.handlers.ts
+++ b/backend/src/socket/notification.handlers.ts
@@ -1,0 +1,14 @@
+import type { Server } from "socket.io";
+import { notificationEmitter } from "../events/notification.emitter.js";
+import { notificationRepository } from "../repositories/notification.repository.js";
+
+export function setupNotificationSocket(io: Server): void {
+    notificationEmitter.on('notification:created', async ({ userId }: { userId: number}) => {
+        try {
+            const count = await notificationRepository.getUnreadCount(userId);
+            io.to(`user:${userId}`).emit('unreadNotificationCount', { count });
+        } catch (err) {
+            console.error('Failed to emit unreadNotificationCount:', err);
+        }
+    });
+}

--- a/frontend/src/app/components/Navbar.tsx
+++ b/frontend/src/app/components/Navbar.tsx
@@ -21,21 +21,7 @@ const Navbar = () => {
         const token = getCookie("token");
         if (!token) return;
 
-        const socket =getSocket();
-        const onUnreadMessageCount = (data: { count: number }) => {
-            setMessageCount(data.count);
-        };
-        socket.on('unreadMessageCount', onUnreadMessageCount);
-        return () => {
-            socket.off('unreadMessageCount', onUnreadMessageCount);
-        };
-    }, []);
-
-    useEffect(() => {
         const fetchUnread = async () => {
-            const token = getCookie("token");
-            if (!token) return;
-
             const apiUrl = process.env.NEXT_PUBLIC_API_URL;
             const res = await fetch(`${apiUrl}/api/notifications/unread-count`, {
                 method: 'GET',
@@ -44,14 +30,26 @@ const Navbar = () => {
                     'Content-Type': 'application/json',
                 },
             });
-
             if (!res.ok) return;
-
             const data = await res.json();
-            console.log("data:",data.count)
             setNotificationCount(data.count);
         };
         fetchUnread();
+
+        const socket = getSocket();
+        const onUnreadMessageCount = (data: { count: number }) => {
+            setMessageCount(data.count);
+        };
+        socket.on('unreadMessageCount', onUnreadMessageCount);
+
+        const onUnreadNotificationCount = (data: { count: number }) => {
+            setNotificationCount(data.count);
+        };
+        socket.on('unreadNotificationCount', onUnreadNotificationCount);
+        return () => {
+            socket.off('unreadMessageCount', onUnreadMessageCount);
+            socket.off('unreadNotificationCount', onUnreadNotificationCount);
+        };
     }, [])
 
     return (

--- a/frontend/src/app/components/Navbar.tsx
+++ b/frontend/src/app/components/Navbar.tsx
@@ -23,16 +23,22 @@ const Navbar = () => {
 
         const fetchUnread = async () => {
             const apiUrl = process.env.NEXT_PUBLIC_API_URL;
-            const res = await fetch(`${apiUrl}/api/notifications/unread-count`, {
-                method: 'GET',
-                headers: {
-                    'Authorization': `Bearer ${token}`,
-                    'Content-Type': 'application/json',
-                },
-            });
-            if (!res.ok) return;
-            const data = await res.json();
-            setNotificationCount(data.count);
+            const headers = {
+                'Authorization': `Bearer ${token}`,
+                'Content-Type': 'application/json',
+            };
+            const [notifRes, msgRes] = await Promise.all([
+                fetch(`${apiUrl}/api/notifications/unread-count`, { headers }),
+                fetch(`${apiUrl}/api/conversations/unread-count`, { headers }),
+            ]);
+            if (notifRes.ok) {
+                const data = await notifRes.json();
+                setNotificationCount(data.count);
+            }
+            if (msgRes.ok) {
+                const data = await msgRes.json();
+                setMessageCount(data.count);
+            }
         };
         fetchUnread();
 

--- a/frontend/src/app/components/Navbar.tsx
+++ b/frontend/src/app/components/Navbar.tsx
@@ -5,15 +5,31 @@ import { useRouter } from "next/navigation";
 import NavbarButtonElement from "./NavbarButtonElement";
 import { mdiAccount, mdiMagnify, mdiBell, mdiChat, mdiCog, mdiLogout } from '@mdi/js';
 import { getCookie, deleteCookie } from "@/utils/cookie.util";
+import { getSocket } from "@/lib/socket";
 
 const Navbar = () => {
     const [notificationCount, setNotificationCount] = useState(0);
+    const [messageCount, setMessageCount] = useState(0);
     const router = useRouter();
 
     const handleLogout = () => {
         deleteCookie('token');
         router.push('/login');
     };
+
+    useEffect(() => {
+        const token = getCookie("token");
+        if (!token) return;
+
+        const socket =getSocket();
+        const onUnreadMessageCount = (data: { count: number }) => {
+            setMessageCount(data.count);
+        };
+        socket.on('unreadMessageCount', onUnreadMessageCount);
+        return () => {
+            socket.off('unreadMessageCount', onUnreadMessageCount);
+        };
+    }, []);
 
     useEffect(() => {
         const fetchUnread = async () => {
@@ -43,7 +59,7 @@ const Navbar = () => {
             <NavbarButtonElement path={mdiAccount} size={1.3} title={"Profile"} color={"black"} onClick={() => router.push('/profile')} />
             <NavbarButtonElement path={mdiMagnify} size={1.3} title={"Search"} color={"black"} onClick={() => router.push('/search')} />
             <NavbarButtonElement path={mdiBell} size={1.3} title={"Notifications"} color={"black"} badgeCount={notificationCount} onClick={() => router.push('/notifications')} />
-            <NavbarButtonElement path={mdiChat} size={1.3} title={"Messages"} color={"black"} onClick={() => router.push('/chat')} />
+            <NavbarButtonElement path={mdiChat} size={1.3} title={"Messages"} color={"black"} badgeCount={messageCount} onClick={() => router.push('/chat')} />
             <NavbarButtonElement path={mdiCog} size={1.3} title={"Settings"} color={"black"} onClick={() => router.push('/settings')} />
             <NavbarButtonElement path={mdiLogout} size={1.3} title={"Logout"} color={"black"} onClick={handleLogout} />
         </div>


### PR DESCRIPTION
## Summary
- Add real-time unread **message** badge on the Navbar using the existing `unreadMessageCount` socket event (emitted on connect, send, and read)
- Add real-time unread **notification** badge using a new **EventEmitter pattern** that decouples the service layer from Socket.IO — notifications created via REST (like, match, view) now push badge updates instantly without polling
- Merge Navbar badge logic into a single `useEffect` with proper socket cleanup

## Screen Shot
<img width="698" height="423" alt="スクリーンショット 2026-03-11 18 41 06" src="https://github.com/user-attachments/assets/0693bbbc-3ec0-4d1d-b4c6-7a4f6d7c157a" />

# Related Issues
Closes #23 
Closes #26 