### PR TITLE
[FEATURE] Implement Password Reset on sign in page

### DIFF
--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -4,6 +4,7 @@ import pool from '../database/init.js';
 import bcrypt from 'bcrypt';
 import { sendEmail } from '../utils/email.util.js';
 import { authService } from '../services/auth.service.js';
+import { passwordResetService } from '../services/password_reset.service.js';
 import type { RegisterSchema } from '../types/auth.types.js';
 
 type Request = express.Request;
@@ -67,5 +68,35 @@ export const login = async (req: Request, res: Response) => {
     res.status(200).json({ message: 'Login successful', user, token });
   } catch (error) {
     res.status(400).json({ error: error instanceof Error ? error.message : "Invalid input" });
+  }
+};
+
+export const forgotPassword = async (req: Request, res: Response) => {
+  try {
+    const { email } = req.body;
+    if (!email)
+      return res.status(400).json({ error: 'Email is required' });
+
+    await passwordResetService.requestReset(email);
+    res.status(200).json({ message: 'If this email is registered, a reset link has been sent.' });
+  } catch (err: any) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+};
+
+export const resetPassword = async (req: Request, res: Response) => {
+  try {
+    const { token, password } = req.body;
+    if (!token || !password)
+      return res.status(400).json({ error: 'Token and password are required' });
+
+    if (password.length < 3 || password.length > 20)
+      return res.status(400).json({ error: 'Password must be between 3 and 20 characters' });
+
+    await passwordResetService.resetPassword(token, password);
+    res.status(200).json({ message: 'Password has been reset successfully' });
+  } catch (error) {
+    res.status(400).json({ error: error instanceof Error ? error.message : 'Invalid request' });
   }
 };

--- a/backend/src/database/init.ts
+++ b/backend/src/database/init.ts
@@ -9,6 +9,7 @@ import { createConversationTable } from '../models/converstation.model.js';
 import { createMessageTable } from '../models/messages.model.js';
 import { createNotificationTable } from '../models/notification.model.js';
 import { createReportTable } from '../models/report.model.js';
+import { createPasswordResetTable } from '../models/password_reset.model.js';
 
 let pool: any;
 
@@ -43,6 +44,7 @@ export const initDB = async () => {
       await pool.query(createMessageTable);
       await pool.query(createNotificationTable);
       await pool.query(createReportTable);
+      await pool.query(createPasswordResetTable);
       console.log('✅ Database initialized');
       return;
     } catch (err) {

--- a/backend/src/models/password_reset.model.ts
+++ b/backend/src/models/password_reset.model.ts
@@ -1,0 +1,10 @@
+export const createPasswordResetTable = `
+CREATE TABLE IF NOT EXISTS password_resets (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  token UUID UNIQUE NOT NULL,
+  expires_at TIMESTAMP NOT NULL,
+  used BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+`;

--- a/backend/src/repositories/password_reset.repository.ts
+++ b/backend/src/repositories/password_reset.repository.ts
@@ -1,0 +1,31 @@
+import pool from '../database/init.js';
+
+export const passwordResetRepository = {
+  create: async (userId: number, token: string, expiresAt: Date) => {
+    const query = `
+      INSERT INTO password_resets (user_id, token, expires_at)
+      VALUES ($1, $2, $3)
+      RETURNING id, user_id, token, expires_at, created_at
+    `;
+    const res = await pool.query(query, [userId, token, expiresAt]);
+    return res.rows[0];
+  },
+
+  findValidByToken: async (token: string) => {
+    const query = `
+      SELECT * FROM password_resets
+      WHERE token = $1 AND used = FALSE AND expires_at > NOW()
+      LIMIT 1
+    `;
+    const res = await pool.query(query, [token]);
+    return res.rows[0];
+  },
+
+  markUsed: async (id: number) => {
+    await pool.query('UPDATE password_resets SET used = TRUE WHERE id = $1', [id]);
+  },
+
+  deleteByUserId: async (userId: number) => {
+    await pool.query('DELETE FROM password_resets WHERE user_id = $1 AND used = FALSE', [userId]);
+  },
+};

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -1,10 +1,12 @@
 import { Router } from 'express';
-import { signup, login, completeRegistration } from '../controllers/auth.controller.js';
+import { signup, login, completeRegistration, forgotPassword, resetPassword } from '../controllers/auth.controller.js';
 
 const router = Router();
 
 router.post('/signup', signup);
 router.post('/login', login);
 router.post('/register', completeRegistration);
+router.post('/forgot-password', forgotPassword);
+router.post('/reset-password', resetPassword);
 
 export default router;

--- a/backend/src/services/password_reset.service.ts
+++ b/backend/src/services/password_reset.service.ts
@@ -1,0 +1,49 @@
+import { v4 as uuidv4 } from 'uuid';
+import bcrypt from 'bcrypt';
+import { passwordResetRepository } from '../repositories/password_reset.repository.js';
+import { authRepository } from '../repositories/auth.repository.js';
+import { sendEmail } from '../utils/email.util.js';
+
+const RESET_TOKEN_EXPIRY_HOURS = 1;
+
+export const passwordResetService = {
+  requestReset: async (email: string) => {
+    const user = await authRepository.findUserByEmail(email);
+    if (!user) return; // silent — don't leak whether email exists
+
+    await passwordResetRepository.deleteByUserId(user.id);
+
+    const token = uuidv4();
+    const expiresAt = new Date(Date.now() + RESET_TOKEN_EXPIRY_HOURS * 60 * 60 * 1000);
+
+    await passwordResetRepository.create(user.id, token, expiresAt);
+
+    const resetLink = `${process.env.FRONTEND_URL}/reset-password?token=${token}`;
+    await sendEmail({
+      to: email,
+      subject: 'Reset your Matcha password',
+      text: `Click here to reset your password: ${resetLink}\n\nThis link expires in ${RESET_TOKEN_EXPIRY_HOURS} hour(s).`,
+      html: `
+        <h2>Reset your password</h2>
+        <p>Click the link below to reset your Matcha password:</p>
+        <a href="${resetLink}">${resetLink}</a>
+        <p>This link expires in ${RESET_TOKEN_EXPIRY_HOURS} hour(s). If you didn't request this, you can safely ignore this email.</p>
+      `,
+    });
+  },
+
+  resetPassword: async (token: string, newPassword: string) => {
+    const resetRecord = await passwordResetRepository.findValidByToken(token);
+    if (!resetRecord) throw new Error('Invalid or expired reset token');
+
+    const hashedPassword = await bcrypt.hash(newPassword, 10);
+
+    const { default: pool } = await import('../database/init.js');
+    await pool.query('UPDATE users SET password_hash = $1, updated_at = NOW() WHERE id = $2', [
+      hashedPassword,
+      resetRecord.user_id,
+    ]);
+
+    await passwordResetRepository.markUsed(resetRecord.id);
+  },
+};

--- a/frontend/src/app/(auth)/forgot-password/page.tsx
+++ b/frontend/src/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import Title from "@/app/components/Title";
+import InputForm from "@/app/components/InputForm";
+import NextButton from "@/app/components/Buttons/NextButton";
+import { useState } from "react";
+import { toast } from "sonner";
+import Link from "next/link";
+
+const forgotPasswordSchema = z.object({
+  email: z.string().email(),
+});
+
+type ForgotPasswordSchema = z.infer<typeof forgotPasswordSchema>;
+
+export default function ForgotPasswordPage() {
+  const [submitted, setSubmitted] = useState(false);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<ForgotPasswordSchema>({
+    resolver: zodResolver(forgotPasswordSchema),
+    mode: "onBlur",
+    defaultValues: { email: "" },
+  });
+
+  const onSubmit = async (data: ForgotPasswordSchema) => {
+    try {
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+      const response = await fetch(`${apiUrl}/api/auth/forgot-password`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: data.email }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        toast.error(errorData.error ?? "Something went wrong");
+        return;
+      }
+
+      setSubmitted(true);
+    } catch {
+      toast.error("Network error. Please try again.");
+    }
+  };
+
+  if (submitted) {
+    return (
+      <div className="flex flex-1 flex-col max-w-md items-center gap-12">
+        <Title
+          title="Check Your Email"
+          subTitle="If an account exists with that email, we've sent a password reset link. Please check your inbox."
+        />
+        <Link
+          href="/login"
+          className="text-secondary hover:underline font-medium"
+        >
+          Back to login
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex justify-center lg:items-center min-h-screen h-full w-full bg-white text-black">
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="flex flex-1 flex-col max-w-md items-center gap-12"
+      >
+        <Title
+          title="Forgot Password"
+          subTitle="Enter your email and we'll send you a link to reset your password."
+        />
+        <InputForm
+          placeholder="Email"
+          type="text"
+          error={errors.email}
+          {...register("email")}
+        />
+        <NextButton text={isSubmitting ? "Sending..." : "Send Reset Link"} disabled={isSubmitting} />
+        <Link
+          href="/login"
+          className="text-secondary hover:underline font-medium"
+        >
+          Back to login
+        </Link>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/app/(auth)/reset-password/page.tsx
+++ b/frontend/src/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import Title from "@/app/components/Title";
+import InputForm from "@/app/components/InputForm";
+import NextButton from "@/app/components/Buttons/NextButton";
+import { useSearchParams, useRouter } from "next/navigation";
+import { toast } from "sonner";
+import Link from "next/link";
+import { Suspense } from "react";
+
+const resetPasswordSchema = z
+  .object({
+    password: z
+      .string()
+      .min(3, "Password must be at least 3 characters")
+      .max(20, "Password must be at most 20 characters"),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+type ResetPasswordSchema = z.infer<typeof resetPasswordSchema>;
+
+function ResetPasswordForm() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const token = searchParams.get("token");
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<ResetPasswordSchema>({
+    resolver: zodResolver(resetPasswordSchema),
+    mode: "onBlur",
+    defaultValues: { password: "", confirmPassword: "" },
+  });
+
+  if (!token) {
+    return (
+      <div className="flex flex-1 flex-col max-w-md items-center gap-12">
+        <Title
+          title="Invalid Link"
+          subTitle="This password reset link is invalid or has expired."
+        />
+        <Link
+          href="/forgot-password"
+          className="text-secondary hover:underline font-medium"
+        >
+          Request a new reset link
+        </Link>
+      </div>
+    );
+  }
+
+  const onSubmit = async (data: ResetPasswordSchema) => {
+    try {
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+      const response = await fetch(`${apiUrl}/api/auth/reset-password`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token, password: data.password }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        toast.error(errorData.error ?? "Failed to reset password");
+        return;
+      }
+
+      toast.success("Password reset successful! Please log in.");
+      router.push("/login");
+    } catch {
+      toast.error("Network error. Please try again.");
+    }
+  };
+
+  return (
+    <div className="flex justify-center lg:items-center min-h-screen h-full w-full bg-white text-black">
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="flex flex-1 flex-col max-w-md items-center gap-12"
+      >
+        <Title
+          title="Reset Password"
+          subTitle="Enter your new password below."
+        />
+        <InputForm
+          placeholder="New Password"
+          type="password"
+          error={errors.password}
+          {...register("password")}
+        />
+        <InputForm
+          placeholder="Confirm Password"
+          type="password"
+          error={errors.confirmPassword}
+          {...register("confirmPassword")}
+        />
+        <NextButton
+          text={isSubmitting ? "Resetting..." : "Reset Password"}
+          disabled={isSubmitting}
+        />
+        <Link
+          href="/login"
+          className="text-secondary hover:underline font-medium"
+        >
+          Back to login
+        </Link>
+      </form>
+    </div>
+  );
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense>
+      <ResetPasswordForm />
+    </Suspense>
+  );
+}

--- a/frontend/src/app/components/LoginMain.tsx
+++ b/frontend/src/app/components/LoginMain.tsx
@@ -10,6 +10,7 @@ import NextButton from "@/app/components/Buttons/NextButton";
 import { useRouter } from "next/navigation";
 import { setCookie } from "@/utils/cookie.util";
 import { toast } from "sonner";
+import Link from "next/link";
 
 const loginSchema = registerSchema.pick({
     email: true,
@@ -72,6 +73,11 @@ export default function LoginForm() {
           <Title title="Welcome back" subTitle="Sign in to your Matcha account."/>
           <InputForm placeholder="Email" type="text" error={errors.email} {...register("email")}/>
           <InputForm placeholder="Password" type="password" error={errors.password} {...register("password")}/>
+          <div className="w-full text-right">
+            <Link href="/forgot-password" className="text-sm text-secondary hover:underline">
+              Forgot password?
+            </Link>
+          </div>
           <NextButton text="Log in"/>
       </form>
     </div>


### PR DESCRIPTION
## Summary
Adds forgot-password flow: users request a reset from the login page, receive an email with a link, and set a new password.

## Changes
### Backend
- New password_resets table (token, expiry, used flag)
- POST /api/auth/forgot-password — sends reset email (no user enumeration)
- POST /api/auth/reset-password — validates token and updates password
- Token lifetime: 1 hour

### Frontend
- /forgot-password — email form + success state
- /reset-password — new password form with token validation
- "Forgot password?" link on login page

### Related Issue
Closes #29 