### PR TITLE
[FIX] Add realtime notification list updates via socket

### DIFF
--- a/backend/src/repositories/notification.repository.ts
+++ b/backend/src/repositories/notification.repository.ts
@@ -23,6 +23,27 @@ export const notificationRepository = {
     const result = await pool.query(query, [userId]);
     return result.rows;
   },
+
+  getNotificationById: async (notificationId: number) => {
+    const query = `
+      SELECT
+        n.id,
+        n.type,
+        n.actor_id,
+        u.username,
+        u.first_name,
+        u.last_name,
+        u.icon_url,
+        n.reference_id,
+        n.is_read,
+        n.created_at
+      FROM notifications n
+      JOIN users u ON u.id = n.actor_id
+      WHERE n.id = $1
+    `;
+    const result = await pool.query(query, [notificationId]);
+    return result.rows[0];
+  },
     
   createNotification: async (userId: number, actorId: number, type: NotificationType, referenceId?: number) => {
     const query = `

--- a/backend/src/services/notification.service.ts
+++ b/backend/src/services/notification.service.ts
@@ -6,13 +6,19 @@ export const notificationService = {
     getNotifications: async (userId: number) => {
         return await notificationRepository.getNotifications(userId);
     },
+
     createNotification: async (userId: number, actorId: number, type: NotificationType, referenceId?: number) => {
         const notification = await notificationRepository.createNotification(userId, actorId, type, referenceId);
         if (notification) {
-            notificationEmitter.emit('notification:created', { userId });
+            const fullNotification = await notificationRepository.getNotificationById(notification.id);
+            notificationEmitter.emit('notification:created', {
+                userId,
+                notification: fullNotification,
+            });
         }
         return notification;
     },
+
     deleteNotification: async (userId: number, actorId: number, type: NotificationType ) => {
         const result = await notificationRepository.deleteNotification(userId, actorId, type);
         if (result) {
@@ -20,9 +26,11 @@ export const notificationService = {
         }
         return result;
     },
+
     markAsRead: async (notificationId: number, userId: number) => {
         return notificationRepository.markAsRead(notificationId, userId);
     },
+    
     getUnreadCount: async (userId: number) => {
         return notificationRepository.getUnreadCount(userId);
     },

--- a/backend/src/socket/notification.handlers.ts
+++ b/backend/src/socket/notification.handlers.ts
@@ -3,7 +3,16 @@ import { notificationEmitter } from "../events/notification.emitter.js";
 import { notificationRepository } from "../repositories/notification.repository.js";
 
 export function setupNotificationSocket(io: Server): void {
-    notificationEmitter.on('notification:created', async ({ userId }: { userId: number}) => {
+    notificationEmitter.on('notification:created', async ({ userId, notification }: { userId: number; notification: any }) => {
+        try {
+            const count = await notificationRepository.getUnreadCount(userId);
+            io.to(`user:${userId}`).emit('unreadNotificationCount', { count });
+            io.to(`user:${userId}`).emit('newNotification', notification);
+        } catch (err) {
+            console.error('Failed to emit notification events:', err);
+        }
+    });
+    notificationEmitter.on('notification:deleted', async ({ userId }: { userId: number}) => {
         try {
             const count = await notificationRepository.getUnreadCount(userId);
             io.to(`user:${userId}`).emit('unreadNotificationCount', { count });
@@ -11,7 +20,7 @@ export function setupNotificationSocket(io: Server): void {
             console.error('Failed to emit unreadNotificationCount:', err);
         }
     });
-    notificationEmitter.on('notification:deleted', async ({ userId }: { userId: number}) => {
+    notificationEmitter.on('notification:read', async ({ userId }: { userId: number }) => {
         try {
             const count = await notificationRepository.getUnreadCount(userId);
             io.to(`user:${userId}`).emit('unreadNotificationCount', { count });

--- a/frontend/src/app/notifications/NotificationsClient.tsx
+++ b/frontend/src/app/notifications/NotificationsClient.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image'
 import { getCookie } from '@/utils/cookie.util'
 import { useRouter } from 'next/navigation'
 import { formatTimeAgo } from '@/utils/format'
+import { getSocket } from '@/lib/socket'
 
 interface Notification {
   id: number
@@ -46,6 +47,20 @@ export default function NotificationsClient() {
       }
     }
     fetchNotifications()
+  }, [])
+
+  useEffect(() => {
+    const socket = getSocket()
+    const onNewNotification = (notification: Notification) => {
+      setNotifications(prev => {
+        if (prev.some(n => n.id === notification.id)) return prev
+        return [notification, ...prev]
+      })
+    }
+    socket.on('newNotification', onNewNotification)
+    return () => {
+      socket.off('newNotification', onNewNotification)
+    }
   }, [])
 
   const handleClick = async (n: Notification) => {


### PR DESCRIPTION
## Summary
- Previously, the notification badge count updated in realtime via socket, but the notification list page required a full reload to show new notifications. This PR fixes the inconsistency by also pushing the full notification payload through the socket.
- Added `getNotificationById` repository method to fetch a single notification with actor info (JOIN with users table), used after INSERT to get the complete data for socket emission.
- The `notification:created` event now includes the full notification object, and the socket handler emits a new `newNotification` event alongside the existing `unreadNotificationCount`.
- Frontend `NotificationsClient` subscribes to `newNotification` and prepends incoming notifications to the list in realtime (with deduplication by id).

## Related Issue
Closes #64 