### PR TITLE
[FEATURE] Implement email-reset and change UI

### DIFF
--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -5,7 +5,9 @@ import bcrypt from 'bcrypt';
 import { sendEmail } from '../utils/email.util.js';
 import { authService } from '../services/auth.service.js';
 import { passwordResetService } from '../services/password_reset.service.js';
+import { emailChangeService } from '../services/change_email.service.js';
 import type { RegisterSchema } from '../types/auth.types.js';
+import { HttpError } from '../errors/HttpError.js';
 
 type Request = express.Request;
 type Response = express.Response;
@@ -116,5 +118,25 @@ export const resetPassword = async (req: Request, res: Response) => {
     res.status(200).json({ message: 'Password has been reset successfully' });
   } catch (error) {
     res.status(400).json({ error: error instanceof Error ? error.message : 'Invalid request' });
+  }
+};
+
+export const confirmEmailChange = async (req: Request, res: Response) => {
+  try {
+    const { token } = req.body;
+    if (!token) {
+      return res.status(400).json({ error: 'Token is required' });
+    }
+
+    const result = await emailChangeService.confirmChange(token);
+    res.status(200).json(result);
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return res.status(error.status).json({ error: error.message });
+    }
+    if (error instanceof Error) {
+      return res.status(400).json({ error: error.message });
+    }
+    res.status(500).json({ error: 'Server error' });
   }
 };

--- a/backend/src/controllers/user.controller.ts
+++ b/backend/src/controllers/user.controller.ts
@@ -1,6 +1,7 @@
 import express from 'express'
 import { type AuthenticatedRequest } from '../middleware/auth.middleware.js'
 import { userService } from '../services/user.service.js'
+import { emailChangeService } from '../services/change_email.service.js'
 import { HttpError } from '../errors/HttpError.js'
 
 type Response = express.Response
@@ -47,6 +48,25 @@ export const updateCurrentUser = async (req: AuthenticatedRequest, res: Response
   } catch (error) {
     res.status(500).json({
       error: error instanceof Error ? error.message : "Failed to update profile"
+    })
+  }
+}
+
+export const updateCurrentUserEmail = async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ error: 'Authentication required' })
+    }
+
+    const { newEmail, currentPassword } = req.body
+    const result = await emailChangeService.requestChange(req.user.userId, newEmail, currentPassword)
+    return res.status(200).json(result)
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return res.status(error.status).json({ error: error.message })
+    }
+    return res.status(500).json({
+      error: error instanceof Error ? error.message : 'Failed to update email'
     })
   }
 }

--- a/backend/src/database/init.ts
+++ b/backend/src/database/init.ts
@@ -10,6 +10,7 @@ import { createMessageTable } from '../models/messages.model.js';
 import { createNotificationTable } from '../models/notification.model.js';
 import { createReportTable } from '../models/report.model.js';
 import { createPasswordResetTable } from '../models/password_reset.model.js';
+import { createChangeEmailTable } from '../models/change_email.model.js';
 
 let pool: any;
 
@@ -45,6 +46,7 @@ export const initDB = async () => {
       await pool.query(createNotificationTable);
       await pool.query(createReportTable);
       await pool.query(createPasswordResetTable);
+      await pool.query(createChangeEmailTable);
       console.log('✅ Database initialized');
       return;
     } catch (err) {

--- a/backend/src/models/change_email.model.ts
+++ b/backend/src/models/change_email.model.ts
@@ -1,0 +1,11 @@
+export const createChangeEmailTable = `
+CREATE TABLE IF NOT EXISTS change_emails (
+  id SERIAL PRIMARY KEY,
+  new_email VARCHAR(255) NOT NULL,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  token UUID UNIQUE NOT NULL,
+  expires_at TIMESTAMP NOT NULL,
+  used BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+`;

--- a/backend/src/repositories/change_email.repository.ts
+++ b/backend/src/repositories/change_email.repository.ts
@@ -1,0 +1,31 @@
+import pool from '../database/init.js';
+
+export const emailChangeRepository = {
+  create: async (userId: number, newEmail:string, token: string, expiresAt: Date) => {
+    const query = `
+      INSERT INTO change_emails (user_id, new_email, token, expires_at)
+      VALUES ($1, $2, $3, $4)
+      RETURNING id, user_id, new_email, token, expires_at, created_at
+    `;
+    const res = await pool.query(query, [userId, newEmail, token, expiresAt]);
+    return res.rows[0];
+  },
+
+  findValidByToken: async (token: string) => {
+    const query = `
+      SELECT * FROM change_emails
+      WHERE token = $1 AND used = FALSE AND expires_at > NOW()
+      LIMIT 1
+    `;
+    const res = await pool.query(query, [token]);
+    return res.rows[0];
+  },
+
+  markUsed: async (id: number) => {
+    await pool.query('UPDATE change_emails SET used = TRUE WHERE id = $1', [id]);
+  },
+
+  deleteByUserId: async (userId: number) => {
+    await pool.query('DELETE FROM change_emails WHERE user_id = $1 AND used = FALSE', [userId]);
+  },
+};

--- a/backend/src/repositories/user.repository.ts
+++ b/backend/src/repositories/user.repository.ts
@@ -44,6 +44,14 @@ function mapUser(row: UserRow) {
 }
 
 export const userRepository = {
+  findCredentialById: async (userId: number) => {
+    const res = await pool.query(
+      'SELECT id, email, password_hash FROM users WHERE id = $1',
+      [userId]
+    )
+    return res.rows[0]
+  },
+
   findUserById: async (userId: number, currentUserId: number) => {
     const query = `
       SELECT

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -1,5 +1,12 @@
 import { Router } from 'express';
-import { signup, login, completeRegistration, forgotPassword, resetPassword } from '../controllers/auth.controller.js';
+import {
+  signup,
+  login,
+  completeRegistration,
+  forgotPassword,
+  resetPassword,
+  confirmEmailChange,
+} from '../controllers/auth.controller.js';
 
 const router = Router();
 
@@ -8,5 +15,6 @@ router.post('/login', login);
 router.post('/register', completeRegistration);
 router.post('/forgot-password', forgotPassword);
 router.post('/reset-password', resetPassword);
+router.post('/confirm-email-change', confirmEmailChange);
 
 export default router;

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -1,11 +1,12 @@
 import { Router } from 'express';
-import { getProfile, getUserById, searchUsers, updateCurrentUser } from '../controllers/user.controller.js';
+import { getProfile, getUserById, searchUsers, updateCurrentUser, updateCurrentUserEmail } from '../controllers/user.controller.js';
 import { authenticateToken } from '../middleware/auth.middleware.js';
 
 const router = Router();
 
 router.get('/me', authenticateToken, getProfile);
 router.patch('/me', authenticateToken, updateCurrentUser);
+router.patch('/me/email', authenticateToken, updateCurrentUserEmail);
 router.get('/search', authenticateToken, searchUsers);
 router.get('/:id', authenticateToken, getUserById);
 

--- a/backend/src/services/change_email.service.ts
+++ b/backend/src/services/change_email.service.ts
@@ -1,0 +1,47 @@
+import { v4 as uuidv4 } from 'uuid';
+import { emailChangeRepository } from '../repositories/change_email.repository.js';
+import { authRepository } from '../repositories/auth.repository.js';
+import { sendEmail } from '../utils/email.util.js';
+
+const VERIFY_TOKEN_EXPIRY_HOURS = 1;
+
+export const emailChangeService = {
+  requestReset: async (userId: number, newEmail: string) => {
+    const user = await authRepository.findUserByEmail(newEmail);
+    if (user) return; // silent — don't leak whether email exists
+    await emailChangeRepository.deleteByUserId(userId);
+
+    const token = uuidv4();
+    const expiresAt = new Date(Date.now() + VERIFY_TOKEN_EXPIRY_HOURS * 60 * 60 * 1000);
+
+    await emailChangeRepository.create(userId, newEmail, token, expiresAt);
+
+    const verifyLink = `${process.env.FRONTEND_URL}/confirm-email-change?token=${token}`;
+    await sendEmail({
+    to: newEmail,
+    subject: 'Confirm your new email address',
+    text: `Click here to confirm your new email address: ${verifyLink}\n\nThis link expires in ${VERIFY_TOKEN_EXPIRY_HOURS} hour(s). If you didn’t request this change, you can ignore this email.`,
+    html: `
+        <h2>Confirm your email change</h2>
+        <p>We received a request to update your email address.</p>
+        <p>Click the link below to confirm your new email:</p>
+        <a href="${verifyLink}">${verifyLink}</a>
+        <p>This link expires in ${VERIFY_TOKEN_EXPIRY_HOURS} hour(s).</p>
+        <p>If you didn’t request this change, you can safely ignore this email and your current email will remain unchanged.</p>
+    `,
+    })
+  },
+
+  changeEmail: async (token: string) => {
+    const record = await emailChangeRepository.findValidByToken(token);
+    if (!record) throw new Error('Invalid or expired reset token');
+
+    const { default: pool } = await import('../database/init.js');
+    await pool.query('UPDATE users SET email = $1, updated_at = NOW() WHERE id = $2', [
+      record.new_email,
+      record.user_id,
+    ]);
+
+    await emailChangeRepository.markUsed(record.id);
+  },
+};

--- a/backend/src/services/change_email.service.ts
+++ b/backend/src/services/change_email.service.ts
@@ -1,27 +1,59 @@
 import { v4 as uuidv4 } from 'uuid';
+import bcrypt from 'bcrypt';
 import { emailChangeRepository } from '../repositories/change_email.repository.js';
 import { authRepository } from '../repositories/auth.repository.js';
+import { userRepository } from '../repositories/user.repository.js';
 import { sendEmail } from '../utils/email.util.js';
+import { HttpError } from '../errors/HttpError.js';
 
 const VERIFY_TOKEN_EXPIRY_HOURS = 1;
 
 export const emailChangeService = {
-  requestReset: async (userId: number, newEmail: string) => {
-    const user = await authRepository.findUserByEmail(newEmail);
-    if (user) return; // silent — don't leak whether email exists
+  requestChange: async (userId: number, newEmail: string, currentPassword: string) => {
+    const normalizedEmail = newEmail.trim().toLowerCase();
+    const password = currentPassword.trim();
+
+    if (!normalizedEmail || !password) {
+      throw new HttpError(400, 'New email and current password are required');
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(normalizedEmail)) {
+      throw new HttpError(400, 'Invalid email format');
+    }
+
+    const currentUser = await userRepository.findCredentialById(userId);
+    if (!currentUser) {
+      throw new HttpError(404, 'User not found');
+    }
+
+    if (normalizedEmail === currentUser.email) {
+      throw new HttpError(400, 'New email must be different from current email');
+    }
+
+    const isPasswordValid = await bcrypt.compare(password, currentUser.password_hash);
+    if (!isPasswordValid) {
+      throw new HttpError(401, 'Current password is incorrect');
+    }
+
+    const existing = await authRepository.findUserByEmail(normalizedEmail);
+    if (existing && existing.id !== userId) {
+      throw new HttpError(409, 'This email is already in use');
+    }
+
     await emailChangeRepository.deleteByUserId(userId);
 
     const token = uuidv4();
     const expiresAt = new Date(Date.now() + VERIFY_TOKEN_EXPIRY_HOURS * 60 * 60 * 1000);
 
-    await emailChangeRepository.create(userId, newEmail, token, expiresAt);
+    await emailChangeRepository.create(userId, normalizedEmail, token, expiresAt);
 
     const verifyLink = `${process.env.FRONTEND_URL}/confirm-email-change?token=${token}`;
     await sendEmail({
-    to: newEmail,
-    subject: 'Confirm your new email address',
-    text: `Click here to confirm your new email address: ${verifyLink}\n\nThis link expires in ${VERIFY_TOKEN_EXPIRY_HOURS} hour(s). If you didn’t request this change, you can ignore this email.`,
-    html: `
+      to: normalizedEmail,
+      subject: 'Confirm your new email address',
+      text: `Click here to confirm your new email address: ${verifyLink}\n\nThis link expires in ${VERIFY_TOKEN_EXPIRY_HOURS} hour(s). If you didn’t request this change, you can ignore this email.`,
+      html: `
         <h2>Confirm your email change</h2>
         <p>We received a request to update your email address.</p>
         <p>Click the link below to confirm your new email:</p>
@@ -29,12 +61,33 @@ export const emailChangeService = {
         <p>This link expires in ${VERIFY_TOKEN_EXPIRY_HOURS} hour(s).</p>
         <p>If you didn’t request this change, you can safely ignore this email and your current email will remain unchanged.</p>
     `,
-    })
+    });
+
+    await sendEmail({
+      to: currentUser.email,
+      subject: 'Email change requested',
+      text: `A request to change your account email to ${normalizedEmail} was made. If this wasn't you, please secure your account immediately.`,
+    });
+
+    return {
+      message: 'Verification email sent to your new address',
+    };
   },
 
-  changeEmail: async (token: string) => {
+  confirmChange: async (token: string) => {
+    if (!token || !token.trim()) {
+      throw new HttpError(400, 'Token is required');
+    }
+
     const record = await emailChangeRepository.findValidByToken(token);
-    if (!record) throw new Error('Invalid or expired reset token');
+    if (!record) {
+      throw new HttpError(400, 'Invalid or expired verification token');
+    }
+
+    const existing = await authRepository.findUserByEmail(record.new_email);
+    if (existing && existing.id !== record.user_id) {
+      throw new HttpError(409, 'This email is already in use');
+    }
 
     const { default: pool } = await import('../database/init.js');
     await pool.query('UPDATE users SET email = $1, updated_at = NOW() WHERE id = $2', [
@@ -43,5 +96,6 @@ export const emailChangeService = {
     ]);
 
     await emailChangeRepository.markUsed(record.id);
+    return { message: 'Email updated successfully' };
   },
 };

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -15,9 +15,6 @@ export const userService = {
     // Fetch user tags
     const tags = await userRepository.findUserTags(userId)
 
-    // Remove password_hash from response
-    const { password_hash, ...userWithoutPassword } = user
-
     // Check like status if currentUserId is provided
     let isLiked = false
     let isMatch = false
@@ -50,7 +47,7 @@ export const userService = {
       await notificationService.createNotification(userId, currentUserId, "VIEW", currentUserId)
     }
 
-    return { ...userWithoutPassword, tags, isLiked, isMatch, isBlocked, isReported, conversationId }
+    return { ...user, tags, isLiked, isMatch, isBlocked, isReported, conversationId }
   },
 
   updateUserProfile: async (userId: number, data: UpdateUserProfileDTO) => {

--- a/frontend/src/app/(auth)/confirm-email-change/page.tsx
+++ b/frontend/src/app/(auth)/confirm-email-change/page.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useSearchParams, useRouter } from "next/navigation";
+import { Suspense, useState } from "react";
+import Link from "next/link";
+import Title from "@/app/components/Title";
+import NextButton from "@/app/components/Buttons/NextButton";
+import { toast } from "sonner";
+
+function ConfirmEmailChangeContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const token = searchParams.get("token");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isConfirmed, setIsConfirmed] = useState(false);
+
+  const onConfirm = async () => {
+    if (!token) return;
+
+    try {
+      setIsSubmitting(true);
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+      const response = await fetch(`${apiUrl}/api/auth/confirm-email-change`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token }),
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        toast.error(data.error ?? "Failed to confirm email change");
+        return;
+      }
+
+      setIsConfirmed(true);
+      toast.success("Email address updated successfully");
+    } catch {
+      toast.error("Network error. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!token) {
+    return (
+      <div className="flex flex-1 flex-col max-w-md items-center gap-12">
+        <Title
+          title="Invalid Link"
+          subTitle="This email confirmation link is invalid or has expired."
+        />
+        <Link href="/settings" className="text-secondary hover:underline font-medium">
+          Back to settings
+        </Link>
+      </div>
+    );
+  }
+
+  if (isConfirmed) {
+    return (
+      <div className="flex flex-1 flex-col max-w-md items-center gap-12">
+        <Title
+          title="Email Updated"
+          subTitle="Your new email address has been confirmed successfully."
+        />
+        <NextButton text="Go to settings" onClick={() => router.push("/settings")} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex justify-center lg:items-center h-full w-full bg-white text-black">
+      <div className="flex flex-1 flex-col max-w-md items-center gap-12">
+        <Title
+          title="Confirm Email Change"
+          subTitle="Click the button below to confirm your new email address."
+        />
+        <NextButton
+          text={isSubmitting ? "Confirming..." : "Confirm Email Change"}
+          disabled={isSubmitting}
+          onClick={onConfirm}
+        />
+        <Link href="/settings" className="text-secondary hover:underline font-medium">
+          Back to settings
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default function ConfirmEmailChangePage() {
+  return (
+    <Suspense>
+      <ConfirmEmailChangeContent />
+    </Suspense>
+  );
+}

--- a/frontend/src/app/components/Navbar.tsx
+++ b/frontend/src/app/components/Navbar.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import NavbarButtonElement from './NavbarButtonElement'
-import { mdiAccount, mdiMagnify, mdiBell, mdiChat, mdiLogout, mdiPencil } from '@mdi/js'
+import { mdiAccount, mdiMagnify, mdiBell, mdiChat, mdiLogout, mdiCog } from '@mdi/js'
 import { getCookie, deleteCookie } from '@/utils/cookie.util'
 import { getSocket } from '@/lib/socket'
 
@@ -72,13 +72,6 @@ const Navbar = ({ className }: Props) => {
         onClick={() => router.push('/profile')}
       />
       <NavbarButtonElement
-        path={mdiPencil}
-        size={1.2}
-        title={'Edit Profile'}
-        color={'black'}
-        onClick={() => router.push('/profile/edit')}
-      />
-      <NavbarButtonElement
         path={mdiMagnify}
         size={1.2}
         title={'Search'}
@@ -100,6 +93,13 @@ const Navbar = ({ className }: Props) => {
         badgeCount={messageCount}
         color={'black'}
         onClick={() => router.push('/chat')}
+      />
+      <NavbarButtonElement
+        path={mdiCog}
+        size={1.2}
+        title={'Settings'}
+        color={'black'}
+        onClick={() => router.push('/settings')}
       />
       <NavbarButtonElement
         path={mdiLogout}

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Image from 'next/image'
-import Navbar from '@/app/components/Navbar'
 import Header from '@/app/components/Header'
 import { getCookie, deleteCookie } from '@/utils/cookie.util'
 import AppLayout from '../layouts/AppLayout'
@@ -121,7 +120,17 @@ export default function Dashboard() {
   return (
     <AppLayout>
       <div className="max-w-4xl mx-auto p-16">
-        <h1 className="text-3xl font-bold mb-8 text-black">Dashboard</h1>
+        <div className="mb-8 flex items-center justify-between gap-2 sm:gap-4">
+          <h1 className="text-3xl font-bold text-black">Dashboard</h1>
+          <button
+            type="button"
+            onClick={() => router.push('/profile/edit')}
+            className="bg-black text-white text-sm sm:text-base px-3 sm:px-4 py-1.5 sm:py-2 rounded-md whitespace-nowrap hover:opacity-90"
+          >
+            Edit Profile
+          </button>
+        </div>
+
         <div className="bg-white rounded-lg shadow-lg p-6 border border-gray-200">
           <h2 className="text-2xl font-semibold mb-6 text-black">Profile</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,0 +1,179 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { FormEvent } from 'react'
+import { useRouter } from 'next/navigation'
+import AppLayout from '../layouts/AppLayout'
+import { getCookie, deleteCookie } from '@/utils/cookie.util'
+import { toast } from 'sonner'
+
+interface UserSettingsProfile {
+  email: string
+}
+
+export default function SettingsPage() {
+  const [profile, setProfile] = useState<UserSettingsProfile | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [newEmail, setNewEmail] = useState('')
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [isSavingEmail, setIsSavingEmail] = useState(false)
+  const router = useRouter()
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      try {
+        const token = getCookie('token')
+        if (!token) {
+          router.push('/login')
+          return
+        }
+
+        const apiUrl = process.env.NEXT_PUBLIC_API_URL
+        const response = await fetch(`${apiUrl}/api/users/me`, {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json'
+          }
+        })
+
+        if (!response.ok) {
+          if (response.status === 401) {
+            deleteCookie('token')
+            router.push('/login')
+            return
+          }
+          const errorData = await response.json()
+          throw new Error(errorData.error || 'Failed to fetch profile')
+        }
+
+        const data = await response.json()
+        setProfile({ email: data.email })
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'An error occurred')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchProfile()
+  }, [router])
+
+  const handleEmailUpdate = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const trimmedEmail = newEmail.trim().toLowerCase()
+    const trimmedPassword = currentPassword.trim()
+
+    if (!trimmedEmail || !trimmedPassword) {
+      toast.error('Please enter a new email and your current password')
+      return
+    }
+
+    try {
+      setIsSavingEmail(true)
+      const token = getCookie('token')
+      if (!token) {
+        deleteCookie('token')
+        router.push('/login')
+        return
+      }
+
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL
+      const response = await fetch(`${apiUrl}/api/users/me/email`, {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          newEmail: trimmedEmail,
+          currentPassword: trimmedPassword
+        })
+      })
+
+      const payload = await response.json()
+      if (!response.ok) {
+        toast.error(payload.error || 'Failed to request email change')
+        return
+      }
+
+      setNewEmail('')
+      setCurrentPassword('')
+      toast.success(payload.message || 'Verification email sent')
+    } catch {
+      toast.error('Network error. Please try again.')
+    } finally {
+      setIsSavingEmail(false)
+    }
+  }
+
+  return (
+    <AppLayout>
+      <div className="max-w-4xl mx-auto p-16">
+        <h1 className="text-3xl font-bold mb-8 text-black">Settings</h1>
+        <div className="bg-white rounded-lg shadow-lg p-6 border border-gray-200 space-y-8">
+          {loading && <div className="text-black">Loading settings...</div>}
+          {error && <div className="text-red-500">Error: {error}</div>}
+
+          {!loading && !error && profile && (
+            <>
+              <section className="border border-gray-200 rounded-lg p-4">
+                <h2 className="text-lg font-semibold text-black mb-4">Change Email</h2>
+                <div className="mb-4">
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Current Email</label>
+                  <p className="text-black">{profile.email}</p>
+                </div>
+                <form onSubmit={handleEmailUpdate} className="space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">New Email</label>
+                    <input
+                      type="email"
+                      value={newEmail}
+                      onChange={(event) => setNewEmail(event.target.value)}
+                      placeholder="new-email@example.com"
+                      className="w-full border border-gray-300 rounded-md px-3 py-2 text-black"
+                      required
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Current Password</label>
+                    <input
+                      type="password"
+                      value={currentPassword}
+                      onChange={(event) => setCurrentPassword(event.target.value)}
+                      placeholder="Enter your current password"
+                      className="w-full border border-gray-300 rounded-md px-3 py-2 text-black"
+                      required
+                    />
+                  </div>
+                  <button
+                    type="submit"
+                    disabled={isSavingEmail}
+                    className="bg-black text-white px-4 py-2 rounded-md disabled:opacity-60"
+                  >
+                    {isSavingEmail ? 'Updating...' : 'Update Email'}
+                  </button>
+                </form>
+              </section>
+
+              <section className="border border-gray-200 rounded-lg p-4">
+                <h2 className="text-lg font-semibold text-black mb-2">Reset Password</h2>
+                <p className="text-gray-600 mb-4">
+                  Use the existing reset flow to send a password reset email.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => router.push('/forgot-password')}
+                  className="bg-white text-black border border-gray-300 px-4 py-2 rounded-md hover:bg-gray-50"
+                >
+                  Go to Password Reset
+                </button>
+              </section>
+            </>
+          )}
+        </div>
+      </div>
+    </AppLayout>
+  )
+}


### PR DESCRIPTION
## Summary
This PR implements a full email change verification flow (request + confirm) and updates account navigation UX.

- Adds backend support for two-step email change:
   - `PATCH /api/users/me/email` now validates current password and sends a verification email to the new address.
   - `POST /api/auth/confirm-email-change` confirms token and applies the email update.
- Integrates existing `change_email` domain files into the real flow:
   - Service now handles validation, token issuance, email sending, and confirmation.
   - DB init now creates `change_emails` table.
- cleanup old temporary path from `user.service`.
- Updates frontend settings behavior:
   - Settings page now requests email change verification instead of immediate email mutation.
   - Adds new `confirm-email-change` page to consume token link and finalize update.
- Navigation/profile UX updates:
   - Adds Settings entry in navbar.
   - Moves Edit Profile action from navbar to profile page header.

## Related Issue
Closes #70 
Closes #36 