### PR TITLE
[FIX] few bugs about GPS 

### DIFF
--- a/frontend/src/app/components/LocationField.tsx
+++ b/frontend/src/app/components/LocationField.tsx
@@ -43,6 +43,7 @@ export default function LocationField({ location, latitude, longitude, onChange,
       const verified = data.display_name || location
 
       setVerifiedLocation(verified)
+      setApiError(null)
       onChange(verified, data.latitude, data.longitude)
     } catch {
       setApiError('Could not verify location')
@@ -52,14 +53,17 @@ export default function LocationField({ location, latitude, longitude, onChange,
   }
 
   const enableGPS = () => {
+    setApiError(null)
     navigator.geolocation.getCurrentPosition(async (pos) => {
       const { latitude, longitude } = pos.coords
       const apiUrl = process.env.NEXT_PUBLIC_API_URL
       const res = await fetch(`${apiUrl}/api/geocoding/reverse?lat=${latitude}&lon=${longitude}`)
       const data = await res.json()
 
-      setVerifiedLocation(data.address)
-      onChange(data.address, latitude, longitude)
+      const address = data.address ?? location ?? ''
+      setVerifiedLocation(address)
+      setApiError(null)
+      onChange(address, latitude, longitude)
     })
   }
 
@@ -69,9 +73,10 @@ export default function LocationField({ location, latitude, longitude, onChange,
       
       <div className="flex gap-2">
         <input
-          value={location}
+          value={location ?? ''}
           onChange={(e) => {
             setVerifiedLocation(null)
+            setApiError(null)
             onChange(e.target.value, 0, 0)
           }}
           className="border-b border-gray-300 p-2 flex-1 focus:outline-none"

--- a/frontend/src/app/profile/edit/EditForm.tsx
+++ b/frontend/src/app/profile/edit/EditForm.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { z } from 'zod'
-import { profileEditSchema, profilePatchSchema } from '@/app/schema'
+import { profileEditSchema } from '@/app/schema'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import InputForm from '@/app/components/InputForm'
@@ -71,9 +71,9 @@ export default function EditForm() {
           firstName: user.firstName,
           lastName: user.lastName,
           birthday: user.birthday?.split('T')[0],
-          location: user.location,
-          latitude: user.latitude,
-          longitude: user.longitude,
+          location: user.location ?? '',
+          latitude: user.latitude ?? 0,
+          longitude: user.longitude ?? 0,
           locationVerified: true,
           gender: user.gender,
           lookingFor: user.lookingFor,
@@ -120,10 +120,8 @@ export default function EditForm() {
         throw new Error(errorData.error || 'Failed to fetch profile')
       }
 
-      const res = await response.json()
-
       toast.success('profile updated')
-    } catch (err) {
+    } catch {
       toast.error('Error updating profile')
     }
   }
@@ -159,9 +157,9 @@ export default function EditForm() {
 
       {/* Location */}
       <LocationField
-        location={watch('location')}
-        latitude={watch('latitude')}
-        longitude={watch('longitude')}
+        location={watch('location') ?? ''}
+        latitude={watch('latitude') ?? 0}
+        longitude={watch('longitude') ?? 0}
         error={errors.locationVerified ?? errors.location}
         onChange={(loc, lat, lon) => {
           setValue('location', loc)


### PR DESCRIPTION
## Summary
- Fixes a React controlled/uncontrolled input warning in profile location editing by ensuring location, latitude, and longitude always have safe fallback values.
- Prevents stale "Could not verify location" errors from lingering by clearing apiError when the user edits location text, starts GPS lookup, or successfully verifies a location.
- Improves GPS reverse-geocoding resilience by falling back to a safe address string before updating form state.

## Related Issue
Closes #71 