### PR TITLE
[FIX] Chat / Profile page responsive bug

### DIFF
--- a/frontend/src/app/chat/ChatBox.tsx
+++ b/frontend/src/app/chat/ChatBox.tsx
@@ -273,7 +273,7 @@ const ChatBox = ({ conversationId }: ChatBoxProps) => {
          ]}
        />
       </header>
-      <main className="flex-1 overflow-y-auto p-4 space-y-4">
+      <main className="flex-1 max-h-[calc(100vh-300px)] md:max-h-[calc(100vh-250px)] overflow-y-auto p-4 space-y-4">
         {messages.map((msg) => (
           <MessageBubble key={msg.id} message={msg} />
         ))}

--- a/frontend/src/app/user/[id]/page.tsx
+++ b/frontend/src/app/user/[id]/page.tsx
@@ -290,11 +290,11 @@ export default function UserProfilePage() {
     <AppLayout>
       <div className="max-w-6xl mx-auto p-8">
         <div className="bg-white rounded-lg p-8">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+          <div className="grid grid-cols-1 xl:grid-cols-2 gap-8">
             {/* Left Side - Profile Information */}
             <div className="flex flex-col space-y-6">
               {/* Profile Header */}
-              <div className="flex flex-col lg:flex-row items-center lg:items-start lg:space-x-6">
+              <div className="flex flex-col xl:flex-row items-center xl:items-start xl:space-x-6">
                 {/* Profile Picture - Larger */}
                 {profile.iconUrl ? (
                   <Image
@@ -425,10 +425,10 @@ export default function UserProfilePage() {
             </div>
 
             {/* Right Side - Image Gallery */}
-            <div className="hidden lg:flex gap-4">
+            <div className="hidden xl:flex gap-4">
               {/* Main Image */}
               <div
-                className="flex-1 bg-custom-light rounded-lg overflow-hidden relative min-h-[400px] lg:min-h-[500px]"
+                className="flex-1 bg-custom-light rounded-lg overflow-hidden relative min-h-[400px] xl:min-h-[500px]"
                 onTouchStart={onTouchStart}
                 onTouchMove={onTouchMove}
                 onTouchEnd={onTouchEnd}
@@ -451,7 +451,7 @@ export default function UserProfilePage() {
 
               {/* Thumbnails - Vertical Stack on Right */}
               {hasPhotos && photos.length > 1 && (
-                <div className="hidden lg:flex flex-col gap-2">
+                <div className="hidden xl:flex flex-col gap-2">
                   {photos.map((photo, index) => (
                     <button
                       key={index}
@@ -477,7 +477,7 @@ export default function UserProfilePage() {
             </div>
 
             {/* Mobile Layout - Column */}
-            <div className="lg:hidden flex flex-col gap-4">
+            <div className="xl:hidden flex flex-col gap-4">
               {hasPhotos ? (
                 photos.map((photo, index) => (
                   <div


### PR DESCRIPTION
## Summary

Fixes layout and responsiveness issues in chat and profile pages.

## Changes

* Fixed message container overflow and ensured proper scrolling
* Prevented footer from covering the chat input
* Adjusted profile page trigger width for better responsiveness

## Result

* Stable chat layout with correct scroll behavior
* Input always visible in chat
* Improved responsiveness on profile pages

## Notes

* UI/UX only, no functional changes


Closes #75 

<img width="1166" height="721" alt="image" src="https://github.com/user-attachments/assets/42bcd377-54a7-4a5e-97ea-98e431999f5a" />

<img width="450" height="720" alt="image" src="https://github.com/user-attachments/assets/c56d3316-f4cc-42aa-8cad-53ac49bbdcea" />
