### PR TITLE
[FIX] Notification guard when blocked or reported

### DIFF
--- a/backend/src/repositories/block.repository.ts
+++ b/backend/src/repositories/block.repository.ts
@@ -21,6 +21,20 @@ export const blockRepository = {
     return res.rows.length > 0;
   },
 
+  checkBlockEitherDirection: async (
+    userA: number,
+    userB: number
+  ): Promise<boolean> => {
+    const query = `
+      SELECT 1 FROM blocks
+      WHERE (blocker_id = $1 AND blocked_id = $2)
+        OR (blocker_id = $2 AND blocked_id = $1)
+      LIMIT 1
+    `;
+    const res = await pool.query(query, [userA, userB]);
+    return res.rows.length > 0;
+  },
+
   removeBlock: async (blockerId: number, blockedId: number) => {
     const query = `
       DELETE FROM blocks

--- a/backend/src/repositories/report.repository.ts
+++ b/backend/src/repositories/report.repository.ts
@@ -23,6 +23,20 @@ export const reportRepository = {
     return res.rows.length > 0;
   },
 
+  checkReportEitherDirection: async (
+    userA: number,
+    userB: number
+  ): Promise<boolean> => {
+    const query = `
+      SELECT 1 FROM reports
+      WHERE (reporter_id = $1 AND reported_id = $2)
+        OR (reporter_id = $2 AND reported_id = $1)
+      LIMIT 1
+    `;
+    const res = await pool.query(query, [userA, userB]);
+    return res.rows.length > 0;
+  },
+
   isReported: async (userA: number, userB: number): Promise<boolean> => {
     const query = `
       SELECT 1 FROM reports

--- a/backend/src/services/notification.service.ts
+++ b/backend/src/services/notification.service.ts
@@ -1,6 +1,8 @@
 import { notificationRepository } from "../repositories/notification.repository.js";
 import { notificationEmitter } from "../events/notification.emitter.js";
 import type { NotificationType } from "../types/notification.types.js";
+import { blockRepository } from "../repositories/block.repository.js";
+import { reportRepository } from "../repositories/report.repository.js";
 
 export const notificationService = {
     getNotifications: async (userId: number) => {
@@ -8,6 +10,11 @@ export const notificationService = {
     },
 
     createNotification: async (userId: number, actorId: number, type: NotificationType, referenceId?: number) => {
+        const [blockCheck, reportCheck] = await Promise.all([
+            blockRepository.checkBlockEitherDirection(userId, actorId),
+            reportRepository.checkReportEitherDirection(userId, actorId),
+        ]);
+        if (blockCheck || reportCheck) return;
         const notification = await notificationRepository.createNotification(userId, actorId, type, referenceId);
         if (notification) {
             const fullNotification = await notificationRepository.getNotificationById(notification.id);


### PR DESCRIPTION
## Summary

Add bidirectional checks for block/report and prevent notifications between restricted users.

## Changes

* Symmetric block/report checks
* Guard in `createNotification` to skip restricted users

## Result

No notifications or interactions when either user blocks/reports the other.
