### PR TITLE
[FEATURE] centralize password policy validation 

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,9 @@
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
         "@supabase/supabase-js": "^2.76.1",
+        "@zxcvbn-ts/core": "^3.0.4",
+        "@zxcvbn-ts/language-common": "^3.0.4",
+        "@zxcvbn-ts/language-en": "^3.0.2",
         "bcrypt": "^6.0.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -794,6 +797,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -3494,6 +3498,27 @@
         "win32"
       ]
     },
+    "node_modules/@zxcvbn-ts/core": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@zxcvbn-ts/core/-/core-3.0.4.tgz",
+      "integrity": "sha512-aQeiT0F09FuJaAqNrxynlAwZ2mW/1MdXakKWNmGM1Qp/VaY6CnB/GfnMS2T8gB2231Esp1/maCWd8vTG4OuShw==",
+      "license": "MIT",
+      "dependencies": {
+        "fastest-levenshtein": "1.0.16"
+      }
+    },
+    "node_modules/@zxcvbn-ts/language-common": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@zxcvbn-ts/language-common/-/language-common-3.0.4.tgz",
+      "integrity": "sha512-viSNNnRYtc7ULXzxrQIVUNwHAPSXRtoIwy/Tq4XQQdIknBzw4vz36lQLF6mvhMlTIlpjoN/Z1GFu/fwiAlUSsw==",
+      "license": "MIT"
+    },
+    "node_modules/@zxcvbn-ts/language-en": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@zxcvbn-ts/language-en/-/language-en-3.0.2.tgz",
+      "integrity": "sha512-Zp+zL+I6Un2Bj0tRXNs6VUBq3Djt+hwTwUz4dkt2qgsQz47U0/XthZ4ULrT/RxjwJRl5LwiaKOOZeOtmixHnjg==",
+      "license": "MIT"
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -3818,6 +3843,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -4716,6 +4742,15 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -5484,6 +5519,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -6811,6 +6847,7 @@
       "version": "8.16.3",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -8031,6 +8068,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,9 @@
   "dependencies": {
     "@faker-js/faker": "^10.1.0",
     "@supabase/supabase-js": "^2.76.1",
+    "@zxcvbn-ts/core": "^3.0.4",
+    "@zxcvbn-ts/language-common": "^3.0.4",
+    "@zxcvbn-ts/language-en": "^3.0.2",
     "bcrypt": "^6.0.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -8,6 +8,7 @@ import { passwordResetService } from '../services/password_reset.service.js';
 import { emailChangeService } from '../services/change_email.service.js';
 import type { RegisterSchema } from '../types/auth.types.js';
 import { HttpError } from '../errors/HttpError.js';
+import { validatePasswordPolicy } from '../utils/password.util.js';
 
 type Request = express.Request;
 type Response = express.Response;
@@ -18,6 +19,11 @@ export const signup = async (req: Request, res: Response) => {
     const { email, password } = req.body;
     if (!email || !password)
       return res.status(400).json({ error: 'Missing fields' });
+
+    const passwordError = validatePasswordPolicy(password);
+    if (passwordError) {
+      return res.status(400).json({ error: passwordError });
+    }
 
     const existingUser = await pool.query(
       'SELECT id FROM users WHERE email = $1', [email]
@@ -111,8 +117,10 @@ export const resetPassword = async (req: Request, res: Response) => {
     if (!token || !password)
       return res.status(400).json({ error: 'Token and password are required' });
 
-    if (password.length < 3 || password.length > 20)
-      return res.status(400).json({ error: 'Password must be between 3 and 20 characters' });
+    const passwordError = validatePasswordPolicy(password);
+    if (passwordError) {
+      return res.status(400).json({ error: passwordError });
+    }
 
     await passwordResetService.resetPassword(token, password);
     res.status(200).json({ message: 'Password has been reset successfully' });

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -20,9 +20,9 @@ export const signup = async (req: Request, res: Response) => {
     if (!email || !password)
       return res.status(400).json({ error: 'Missing fields' });
 
-    const passwordError = validatePasswordPolicy(password);
+    const passwordError = await validatePasswordPolicy(password);
     if (passwordError) {
-      return res.status(400).json({ error: passwordError });
+      return res.status(400).json({ error: passwordError, field: 'password' });
     }
 
     const existingUser = await pool.query(
@@ -117,9 +117,9 @@ export const resetPassword = async (req: Request, res: Response) => {
     if (!token || !password)
       return res.status(400).json({ error: 'Token and password are required' });
 
-    const passwordError = validatePasswordPolicy(password);
+    const passwordError = await validatePasswordPolicy(password);
     if (passwordError) {
-      return res.status(400).json({ error: passwordError });
+      return res.status(400).json({ error: passwordError, field: 'password' });
     }
 
     await passwordResetService.resetPassword(token, password);

--- a/backend/src/utils/password.util.ts
+++ b/backend/src/utils/password.util.ts
@@ -5,8 +5,6 @@ const COMMON_PASSWORDS = new Set([
     'azertyulop',
     'azerty123',
     'final9999',
-    'Password',
-    'Azerty123',
     'motdepasse',
     '1234567890',
     'gazeuses',

--- a/backend/src/utils/password.util.ts
+++ b/backend/src/utils/password.util.ts
@@ -1,23 +1,20 @@
-const COMMON_PASSWORDS = new Set([
-    'password',
-    '12345678',
-    '12345679',
-    'azertyulop',
-    'azerty123',
-    'final9999',
-    'motdepasse',
-    '1234567890',
-    'gazeuses',
-    '12345678910',
-    'football',
-    'iloveyou',
-    'realmadrid'
-]);
+import { zxcvbnAsync, zxcvbnOptions } from "@zxcvbn-ts/core";
+import * as zxcvbnCommonPackage from '@zxcvbn-ts/language-common'
+import * as zxcvbnEnPackage from '@zxcvbn-ts/language-en'
+
+zxcvbnOptions.setOptions({
+    graphs: zxcvbnCommonPackage.adjacencyGraphs,
+    dictionary: {
+      ...zxcvbnCommonPackage.dictionary,
+      ...zxcvbnEnPackage.dictionary,
+    },
+})
 
 const MIN_PASSWORD_LENGTH = 8;
 const MAX_PASSWORD_LENGTH = 72;
+const MIN_ZXCVBN_SCORE = 2;
 
-export const validatePasswordPolicy = (rawPassword: unknown): string | null => {
+export const validatePasswordPolicy = async (rawPassword: unknown): Promise<string | null> => {
 if (typeof rawPassword !== 'string') {
     return 'Password is required';
     }
@@ -28,13 +25,9 @@ if (typeof rawPassword !== 'string') {
     if (password.length < MIN_PASSWORD_LENGTH || password.length > MAX_PASSWORD_LENGTH) {
     return `Password must be between ${MIN_PASSWORD_LENGTH} and ${MAX_PASSWORD_LENGTH} characters`;
     }
-    const normalized = password.toLowerCase();
-    if (COMMON_PASSWORDS.has(normalized)) {
-    return 'Password is too common';
-    }
-    // Keeps protection simple: avoid pure alphabetic words only.
-    if (/^[a-zA-Z]+$/.test(password)) {
-    return 'Password must include at least one number or symbol';
+    const result = await zxcvbnAsync(password);
+    if (result.score < MIN_ZXCVBN_SCORE) {
+        return 'Password is too weak. Try a longer or less common password.';
     }
     return null;
 };

--- a/backend/src/utils/password.util.ts
+++ b/backend/src/utils/password.util.ts
@@ -1,0 +1,42 @@
+const COMMON_PASSWORDS = new Set([
+    'password',
+    '12345678',
+    '12345679',
+    'azertyulop',
+    'azerty123',
+    'final9999',
+    'Password',
+    'Azerty123',
+    'motdepasse',
+    '1234567890',
+    'gazeuses',
+    '12345678910',
+    'football',
+    'iloveyou',
+    'realmadrid'
+]);
+
+const MIN_PASSWORD_LENGTH = 8;
+const MAX_PASSWORD_LENGTH = 72;
+
+export const validatePasswordPolicy = (rawPassword: unknown): string | null => {
+if (typeof rawPassword !== 'string') {
+    return 'Password is required';
+    }
+    if (rawPassword !== rawPassword.trim()) {
+    return 'Password cannot start or end with spaces';
+    }
+    const password = rawPassword;
+    if (password.length < MIN_PASSWORD_LENGTH || password.length > MAX_PASSWORD_LENGTH) {
+    return `Password must be between ${MIN_PASSWORD_LENGTH} and ${MAX_PASSWORD_LENGTH} characters`;
+    }
+    const normalized = password.toLowerCase();
+    if (COMMON_PASSWORDS.has(normalized)) {
+    return 'Password is too common';
+    }
+    // Keeps protection simple: avoid pure alphabetic words only.
+    if (/^[a-zA-Z]+$/.test(password)) {
+    return 'Password must include at least one number or symbol';
+    }
+    return null;
+};

--- a/frontend/src/app/(auth)/reset-password/page.tsx
+++ b/frontend/src/app/(auth)/reset-password/page.tsx
@@ -69,11 +69,10 @@ function ResetPasswordForm() {
 
       if (!response.ok) {
         const errorData = await response.json();
-        const msg = errorData.error ?? "Failed to reset password";
-        if (msg.toLowerCase().startsWith("password")) {
-          setError("password", { type: "server", message: msg });
+        if (errorData.field === "password") {
+          setError("password", { type: "server", message: errorData.error });
         } else {
-          toast.error(msg);
+          toast.error(errorData.error ?? "Failed to reset password");
         }
         return;
       }

--- a/frontend/src/app/(auth)/reset-password/page.tsx
+++ b/frontend/src/app/(auth)/reset-password/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { z } from "zod";
+import { passwordSchema } from "@/app/schema";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Title from "@/app/components/Title";
@@ -13,10 +14,7 @@ import { Suspense } from "react";
 
 const resetPasswordSchema = z
   .object({
-    password: z
-      .string()
-      .min(3, "Password must be at least 3 characters")
-      .max(20, "Password must be at most 20 characters"),
+    password: passwordSchema,
     confirmPassword: z.string(),
   })
   .refine((data) => data.password === data.confirmPassword, {
@@ -34,6 +32,8 @@ function ResetPasswordForm() {
   const {
     register,
     handleSubmit,
+    setError,
+    clearErrors,
     formState: { errors, isSubmitting },
   } = useForm<ResetPasswordSchema>({
     resolver: zodResolver(resetPasswordSchema),
@@ -69,7 +69,12 @@ function ResetPasswordForm() {
 
       if (!response.ok) {
         const errorData = await response.json();
-        toast.error(errorData.error ?? "Failed to reset password");
+        const msg = errorData.error ?? "Failed to reset password";
+        if (msg.toLowerCase().startsWith("password")) {
+          setError("password", { type: "server", message: msg });
+        } else {
+          toast.error(msg);
+        }
         return;
       }
 
@@ -94,7 +99,7 @@ function ResetPasswordForm() {
           placeholder="New Password"
           type="password"
           error={errors.password}
-          {...register("password")}
+          {...register("password", { onChange: () => clearErrors("password") })}
         />
         <InputForm
           placeholder="Confirm Password"

--- a/frontend/src/app/components/InputForm.tsx
+++ b/frontend/src/app/components/InputForm.tsx
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { FieldError } from 'react-hook-form'
+import { AiOutlineEye, AiOutlineEyeInvisible } from 'react-icons/ai'
 
 type AllowedInputTypes = 'text' | 'password' | 'email' | 'number' | 'date' | 'checkbox' | 'file'
 
@@ -11,16 +12,29 @@ interface InputFormProps extends Omit<React.InputHTMLAttributes<HTMLInputElement
 }
 
 const InputForm = ({ label, placeholder, type, error, ...props }: InputFormProps) => {
+  const [showPassword, setShowPassword] = useState(false)
+  const isPassword = type === 'password'
   return (
     <div className="flex flex-col gap-2 w-full">
-      {label && <label className="text-sm font-medium text-gray-700">{label}</label>}
-      <input
-        className="border-b border-gray-300 p-2 w-full focus:outline-none"
-        type={type}
-        name={label ? label.toLowerCase() : ''}
-        placeholder={placeholder}
-        {...props}
-      />
+      <div className="relative w-full">
+        <input
+          className="border-b border-gray-300 p-2 w-full focus:outline-none pr-10"
+          type={isPassword && showPassword ? 'text' : type}
+          name={label ? label.toLowerCase() : ''}
+          placeholder={placeholder}
+          {...props}
+        />
+        {isPassword && (
+          <button
+            type="button"
+            onClick={() => setShowPassword((prev) => !prev)}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+            tabIndex={-1}
+          >
+            {showPassword ? <AiOutlineEyeInvisible size={18} /> : <AiOutlineEye size={18} />}
+          </button>
+        )}
+      </div>
       {error && <div className="text-red-500">{error.message}</div>}
     </div>
   )

--- a/frontend/src/app/components/LoginMain.tsx
+++ b/frontend/src/app/components/LoginMain.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { z } from "zod";
-import { registerSchema } from "@/app/schema";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Title from "@/app/components/Title";
@@ -12,9 +11,9 @@ import { setCookie } from "@/utils/cookie.util";
 import { toast } from "sonner";
 import Link from "next/link";
 
-const loginSchema = registerSchema.pick({
-    email: true,
-    password: true
+const loginSchema = z.object({
+  email: z.email(),
+  password: z.string().min(1, { message: "Password is required." }),
 })
 
 type LoginSchema = z.infer<typeof loginSchema>;
@@ -60,7 +59,7 @@ export default function LoginForm() {
                 setCookie('token', result.token, 7); // 7 days expiration
             }
             router.push("/profile");
-        } catch (error) {
+        } catch {
             toast.error('Network error. Please try again.');
         }
     };

--- a/frontend/src/app/components/SignupMain.tsx
+++ b/frontend/src/app/components/SignupMain.tsx
@@ -10,10 +10,13 @@ import NextButton from "@/app/components/Buttons/NextButton";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
-const registerSignupSchema = registerSchema.pick({
-    email: true,
-    password: true,
-    repeatPassword: true
+const registerSignupSchema = z.object({
+    email: registerSchema.shape.email,
+    password: registerSchema.shape.password,
+    repeatPassword: z.string(),
+}).refine((data) => data.password === data.repeatPassword, {
+    message: 'Passwords do not match.',
+    path: ['repeatPassword'],
 })
 
 type registerSignupSchema = z.infer<typeof registerSignupSchema>;
@@ -21,7 +24,7 @@ type registerSignupSchema = z.infer<typeof registerSignupSchema>;
 export default function RegisterBasicForm() {
 
     const router = useRouter();
-    const { register, handleSubmit, formState: { errors }} = useForm<registerSignupSchema>({
+    const { register, handleSubmit, setError, clearErrors, formState: { errors }} = useForm<registerSignupSchema>({
         resolver: zodResolver(registerSignupSchema),
         mode: "onBlur",
         defaultValues: {
@@ -47,7 +50,12 @@ export default function RegisterBasicForm() {
 
             if (!response.ok) {
                 const errorData = await response.json();
-                toast.error(errorData.error || "Signup failed. Please try again.");
+                const msg = errorData.error || "Signup failed. Please try again.";
+                if (msg.toLowerCase().startsWith("password")) {
+                    setError("password", { type: "server", message: msg });
+                } else {
+                    toast.error(msg);
+                }
                 return;
             }
 
@@ -65,7 +73,12 @@ export default function RegisterBasicForm() {
         className="flex flex-1 flex-col items-center max-w-md gap-12">
           <Title title="Create your account" subTitle="Join Matcha – start by entering your email."/>
           <InputForm placeholder="Email" type="text" error={errors.email} {...register("email")}/>
-          <InputForm placeholder="Password" type="password" error={errors.password} {...register("password")}/>
+          <InputForm
+            placeholder="Password"
+            type="password"
+            error={errors.password}
+            {...register("password", { onChange: () => clearErrors("password") })}
+          />
           <InputForm placeholder="Repeat password" type="password" error={errors.repeatPassword} {...register("repeatPassword")}/>
           <NextButton text="Next"/>
           <div className="text-center">

--- a/frontend/src/app/components/SignupMain.tsx
+++ b/frontend/src/app/components/SignupMain.tsx
@@ -50,11 +50,10 @@ export default function RegisterBasicForm() {
 
             if (!response.ok) {
                 const errorData = await response.json();
-                const msg = errorData.error || "Signup failed. Please try again.";
-                if (msg.toLowerCase().startsWith("password")) {
-                    setError("password", { type: "server", message: msg });
+                if (errorData.field === "password") {
+                    setError("password", { type: "server", message: errorData.error });
                 } else {
-                    toast.error(msg);
+                    toast.error(errorData.error || "Signup failed. Please try again.");
                 }
                 return;
             }

--- a/frontend/src/app/schema.ts
+++ b/frontend/src/app/schema.ts
@@ -12,10 +12,30 @@ const longText = (min = 3, max = 150) =>
     .min(min, { message: `Text must contain at least ${min} characters.` })
     .max(max, { message: `Text must contain at most ${max} characters.` })
 
+const COMMON_PASSWORDS = new Set([
+  'password', '12345678', '12345679', 'azertyulop', 'azerty123',
+  'final9999', 'motdepasse', '1234567890', 'gazeuses', '12345678910',
+  'football', 'iloveyou', 'realmadrid'
+])
+
+export const passwordSchema = z
+  .string()
+  .min(8, { message: 'Password must be at least 8 characters.' })
+  .max(72, { message: 'Password must be at most 72 characters.' })
+  .refine((v) => v === v.trim(), {
+    message: 'Password cannot start or end with spaces.',
+  })
+  .refine((v) => !COMMON_PASSWORDS.has(v.toLowerCase()), {
+    message: 'Password is too common. Choose a stronger password.',
+  })
+  .refine((v) => !/^[a-zA-Z]+$/.test(v), {
+    message: 'Password must include at least one number or symbol.',
+  })
+
 export const registerSchema = z.object({
   email: z.email(),
-  password: shortText(),
-  repeatPassword: shortText(),
+  password: passwordSchema,
+  repeatPassword: z.string(),
   firstName: shortText(),
   lastName: shortText(),
   birthday: z
@@ -50,6 +70,9 @@ export const registerSchema = z.object({
     .max(5, { message: 'You can select up to 5 tags.' }),
   iconUrl: z.string().url().nullable(),
   photoUrls: z.array(z.string().url()).max(4)
+}).refine((data) => data.password === data.repeatPassword, {
+  message: 'Passwords do not match.',
+  path: ['repeatPassword'],
 })
 
 export type RegisterSchema = z.infer<typeof registerSchema>

--- a/frontend/src/app/schema.ts
+++ b/frontend/src/app/schema.ts
@@ -12,24 +12,12 @@ const longText = (min = 3, max = 150) =>
     .min(min, { message: `Text must contain at least ${min} characters.` })
     .max(max, { message: `Text must contain at most ${max} characters.` })
 
-const COMMON_PASSWORDS = new Set([
-  'password', '12345678', '12345679', 'azertyulop', 'azerty123',
-  'final9999', 'motdepasse', '1234567890', 'gazeuses', '12345678910',
-  'football', 'iloveyou', 'realmadrid'
-])
-
 export const passwordSchema = z
   .string()
   .min(8, { message: 'Password must be at least 8 characters.' })
   .max(72, { message: 'Password must be at most 72 characters.' })
   .refine((v) => v === v.trim(), {
     message: 'Password cannot start or end with spaces.',
-  })
-  .refine((v) => !COMMON_PASSWORDS.has(v.toLowerCase()), {
-    message: 'Password is too common. Choose a stronger password.',
-  })
-  .refine((v) => !/^[a-zA-Z]+$/.test(v), {
-    message: 'Password must include at least one number or symbol.',
   })
 
 export const registerSchema = z.object({


### PR DESCRIPTION
## Summary
- Add `validatePasswordPolicy` backend utility to enforce password strength (min 8 chars, common password blocklist, requires number or symbol)
- Add shared `passwordSchema` on the frontend mirroring the same rules for instant client-side feedback
- Show password validation errors inline under the input field instead of as toast notifications
- Replace old inconsistent rules (min 3, max 20) in reset-password with the unified policy
- Fix `repeatPassword` to only show "Passwords do not match" instead of redundant policy errors
- Add show/hide password toggle to all password inputs

## Related Issue
Closes #80 