### PR TITLE
[FEATURE] Make user avatars clickable in chat to navigate to profile

### DIFF
--- a/frontend/src/app/chat/ChatBox.tsx
+++ b/frontend/src/app/chat/ChatBox.tsx
@@ -17,6 +17,7 @@ type MessageBubbleFormat = {
   author: string
   username: string
   avatar: string
+  userId: number
   message: string
   date: string
   isMe: boolean
@@ -48,6 +49,7 @@ function mapToBubbleFormat(
     author: fullName,
     username: sender.username,
     avatar: sender.icon_url || '/default-avatar.png',
+    userId: sender.id,
     message: msg.content,
     date: msg.created_at,
     isMe,
@@ -276,15 +278,27 @@ const ChatBox = ({ conversationId }: ChatBoxProps) => {
         >
           <span className="text-2xl">←</span>
         </button>
-        <Image
-          src={otherUser?.icon_url || '/default-avatar.png'}
-          className="w-11 h-11 min-w-11 min-h-11 flex-shrink-0 border border-black rounded-full object-cover aspect-square"
-          alt=""
-          width={44}
-          height={44}
-        />
-        <div className="ml-2 flex-1">
-          <h3 className="font-semibold text-[#2A3D39] text-lg">{fullName}</h3>
+        <button
+          type="button"
+          onClick={() => otherUser && router.push(`/user/${otherUser.id}`)}
+          className="flex-shrink-0 rounded-full focus:outline-none focus:ring-2 focus:ring-[#01AA85]"
+          aria-label={`View ${fullName}'s profile`}
+        >
+          <Image
+            src={otherUser?.icon_url || '/default-avatar.png'}
+            className="w-11 h-11 min-w-11 min-h-11 border border-black rounded-full object-cover aspect-square hover:opacity-80 transition-opacity"
+            alt=""
+            width={44}
+            height={44}
+          />
+        </button>
+        <button
+          type="button"
+          onClick={() => otherUser && router.push(`/user/${otherUser.id}`)}
+          className="ml-2 flex-1 text-left focus:outline-none"
+          aria-label={`View ${fullName}'s profile`}
+        >
+          <h3 className="font-semibold text-[#2A3D39] text-lg hover:underline">{fullName}</h3>
           <p className={`text-sm font-medium ${isOnline ? 'text-green-500' : 'text-gray-400'}`}>
             {isOnline
               ? '● Online'
@@ -292,7 +306,7 @@ const ChatBox = ({ conversationId }: ChatBoxProps) => {
                 ? `● Last seen ${formatTimeAgo(lastSeenAt)}`
                 : '● Offline'}
           </p>
-        </div>
+        </button>
       <KebabMenu
          items={[
            { label: 'Block user', onClick: handleBlock, disabled: actionLoading },

--- a/frontend/src/app/chat/MessageBubble.jsx
+++ b/frontend/src/app/chat/MessageBubble.jsx
@@ -1,20 +1,38 @@
 // src/components/MessageBubble.jsx
 import React from "react";
+import { useRouter } from "next/navigation";
 
 const MessageBubble = ({ message }) => {
+    const router = useRouter();
     const timeStr = new Date(message.date).toLocaleTimeString('fr-FR', {
         hour: '2-digit',
         minute: '2-digit',
         hour12: false
     });
+
+    const handleAvatarClick = () => {
+        if (message.isMe) {
+            router.push('/profile');
+        } else {
+            router.push(`/user/${message.userId}`);
+        }
+    };
+
     return (
         <div className={`flex p-4 ${message.isMe ? "justify-end" : "justify-start"}`}>
             {!message.isMe && (
-                <img
-                    src={message.avatar}
-                    className="w-11 h-11 min-w-11 min-h-11 flex-shrink-0 border border-black rounded-full object-cover aspect-square mr-2"
-                    alt=""
-                />
+                <button
+                    type="button"
+                    onClick={handleAvatarClick}
+                    className="flex-shrink-0 mr-2 rounded-full focus:outline-none focus:ring-2 focus:ring-[#01AA85]"
+                    aria-label={`View ${message.author}'s profile`}
+                >
+                    <img
+                        src={message.avatar}
+                        className="w-11 h-11 min-w-11 min-h-11 border border-black rounded-full object-cover aspect-square hover:opacity-80 transition-opacity cursor-pointer"
+                        alt=""
+                    />
+                </button>
             )}
 
             <div className="flex flex-col max-w-[85vw] md:max-w-[280px]">
@@ -31,11 +49,18 @@ const MessageBubble = ({ message }) => {
             </div>
 
             {message.isMe && (
-                <img
-                    src={message.avatar}
-                    className="w-11 h-11 min-w-11 min-h-11 flex-shrink-0 border border-black rounded-full object-cover aspect-square ml-2"
-                    alt=""
-                />
+                <button
+                    type="button"
+                    onClick={handleAvatarClick}
+                    className="flex-shrink-0 ml-2 rounded-full focus:outline-none focus:ring-2 focus:ring-[#01AA85]"
+                    aria-label="View your profile"
+                >
+                    <img
+                        src={message.avatar}
+                        className="w-11 h-11 min-w-11 min-h-11 border border-black rounded-full object-cover aspect-square hover:opacity-80 transition-opacity cursor-pointer"
+                        alt=""
+                    />
+                </button>
             )}
         </div>
     );


### PR DESCRIPTION
## Summary
Users can open the other person’s profile from the chat thread by clicking their avatar or name in the header, or their avatar on each message. Their own message avatars go to the logged-in profile page.

## Related Issue
Closes #109 