### PR TITLE
[FEATURE] Blocks list in Settings and Likes (sent/received) on Profile

### DIFF
--- a/backend/src/repositories/block.repository.ts
+++ b/backend/src/repositories/block.repository.ts
@@ -47,10 +47,11 @@ export const blockRepository = {
 
   getBlockedUsers: async (userId: number) => {
     const query = `
-      SELECT blocked_id, created_at
-      FROM blocks
-      WHERE blocker_id = $1
-      ORDER BY created_at DESC
+      SELECT b.blocked_id AS id, u.username, u.first_name, u.last_name, u.icon_url, b.created_at
+      FROM blocks b
+      JOIN users u ON u.id = b.blocked_id
+      WHERE b.blocker_id = $1
+      ORDER BY b.created_at DESC
     `;
     const res = await pool.query(query, [userId]);
     return res.rows;

--- a/backend/src/repositories/like.repository.ts
+++ b/backend/src/repositories/like.repository.ts
@@ -52,10 +52,11 @@ export const likeRepository = {
 
   getUserLikes: async (userId: number) => {
     const query = `
-      SELECT liked_id, created_at
-      FROM likes
-      WHERE liker_id = $1
-      ORDER BY created_at DESC
+      SELECT l.liked_id AS id, u.username, u.first_name, u.last_name, u.icon_url, l.created_at
+      FROM likes l
+      JOIN users u ON u.id = l.liked_id
+      WHERE l.liker_id = $1
+      ORDER BY l.created_at DESC
     `;
     const res = await pool.query(query, [userId]);
     return res.rows;
@@ -63,10 +64,11 @@ export const likeRepository = {
 
   getLikedBy: async (userId: number) => {
     const query = `
-      SELECT liker_id, created_at
-      FROM likes
-      WHERE liked_id = $1
-      ORDER BY created_at DESC
+      SELECT l.liker_id AS id, u.username, u.first_name, u.last_name, u.icon_url, l.created_at
+      FROM likes l
+      JOIN users u ON u.id = l.liker_id
+      WHERE l.liked_id = $1
+      ORDER BY l.created_at DESC
     `;
     const res = await pool.query(query, [userId]);
     return res.rows;

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -7,6 +7,15 @@ import Header from '@/app/components/Header'
 import { getCookie, deleteCookie } from '@/utils/cookie.util'
 import AppLayout from '../layouts/AppLayout'
 
+interface LikeUser {
+  id: number
+  username: string
+  first_name: string
+  last_name: string
+  icon_url: string | null
+  created_at: string
+}
+
 interface Tag {
   id: number
   name: string
@@ -35,6 +44,10 @@ export default function Dashboard() {
   const [profile, setProfile] = useState<UserProfile | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [likesSent, setLikesSent] = useState<LikeUser[]>([])
+  const [likesReceived, setLikesReceived] = useState<LikeUser[]>([])
+  const [likesTab, setLikesTab] = useState<'sent' | 'received'>('received')
+  const [likesLoading, setLikesLoading] = useState(true)
   const router = useRouter()
 
   useEffect(() => {
@@ -76,6 +89,27 @@ export default function Dashboard() {
 
     fetchProfile()
   }, [router])
+
+  useEffect(() => {
+    const fetchLikes = async () => {
+      try {
+        const token = getCookie('token')
+        if (!token) return
+        const apiUrl = process.env.NEXT_PUBLIC_API_URL
+        const [sentRes, receivedRes] = await Promise.all([
+          fetch(`${apiUrl}/api/likes/likes`, { headers: { Authorization: `Bearer ${token}` } }),
+          fetch(`${apiUrl}/api/likes/liked-by`, { headers: { Authorization: `Bearer ${token}` } })
+        ])
+        if (sentRes.ok) setLikesSent(await sentRes.json())
+        if (receivedRes.ok) setLikesReceived(await receivedRes.json())
+      } catch {
+        /* non-critical */
+      } finally {
+        setLikesLoading(false)
+      }
+    }
+    fetchLikes()
+  }, [])
 
   if (loading) {
     return (
@@ -244,6 +278,75 @@ export default function Dashboard() {
               </div>
             )}
           </div>
+        </div>
+
+        {/* Likes Section */}
+        <div className="bg-white rounded-lg shadow-lg p-6 border border-gray-200 mt-8">
+          <h2 className="text-2xl font-semibold mb-4 text-black">Likes</h2>
+          <div className="flex border-b border-gray-200 mb-4">
+            <button
+              type="button"
+              onClick={() => setLikesTab('received')}
+              className={`px-4 py-2 text-sm font-medium -mb-px ${
+                likesTab === 'received'
+                  ? 'border-b-2 border-black text-black'
+                  : 'text-gray-500 hover:text-black'
+              }`}
+            >
+              Received ({likesReceived.length})
+            </button>
+            <button
+              type="button"
+              onClick={() => setLikesTab('sent')}
+              className={`px-4 py-2 text-sm font-medium -mb-px ${
+                likesTab === 'sent'
+                  ? 'border-b-2 border-black text-black'
+                  : 'text-gray-500 hover:text-black'
+              }`}
+            >
+              Sent ({likesSent.length})
+            </button>
+          </div>
+
+          {likesLoading && <p className="text-gray-500 text-sm">Loading...</p>}
+
+          {!likesLoading && (
+            <>
+              {(likesTab === 'received' ? likesReceived : likesSent).length === 0 ? (
+                <p className="text-gray-500 text-sm">
+                  {likesTab === 'received' ? 'No one has liked you yet.' : 'You haven\'t liked anyone yet.'}
+                </p>
+              ) : (
+                <ul className="divide-y divide-gray-100">
+                  {(likesTab === 'received' ? likesReceived : likesSent).map((user) => (
+                    <li key={user.id}>
+                      <button
+                        type="button"
+                        onClick={() => router.push(`/user/${user.id}`)}
+                        className="flex items-center gap-3 py-3 w-full hover:bg-gray-50 rounded px-2"
+                      >
+                        {user.icon_url ? (
+                          <img
+                            src={user.icon_url}
+                            alt={user.username}
+                            className="w-10 h-10 rounded-full object-cover"
+                          />
+                        ) : (
+                          <div className="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center text-gray-500 font-semibold">
+                            {user.first_name?.[0]?.toUpperCase() || '?'}
+                          </div>
+                        )}
+                        <div className="text-left">
+                          <p className="text-sm font-medium text-black">{user.first_name} {user.last_name}</p>
+                          <p className="text-xs text-gray-500">@{user.username}</p>
+                        </div>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </>
+          )}
         </div>
       </div>
     </AppLayout>

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -11,6 +11,15 @@ interface UserSettingsProfile {
   email: string
 }
 
+interface BlockedUser {
+  id: number
+  username: string
+  first_name: string
+  last_name: string
+  icon_url: string | null
+  created_at: string
+}
+
 export default function SettingsPage() {
   const [profile, setProfile] = useState<UserSettingsProfile | null>(null)
   const [loading, setLoading] = useState(true)
@@ -18,6 +27,9 @@ export default function SettingsPage() {
   const [newEmail, setNewEmail] = useState('')
   const [currentPassword, setCurrentPassword] = useState('')
   const [isSavingEmail, setIsSavingEmail] = useState(false)
+  const [blockedUsers, setBlockedUsers] = useState<BlockedUser[]>([])
+  const [blockedLoading, setBlockedLoading] = useState(true)
+  const [unblockingId, setUnblockingId] = useState<number | null>(null)
   const router = useRouter()
 
   useEffect(() => {
@@ -59,6 +71,51 @@ export default function SettingsPage() {
 
     fetchProfile()
   }, [router])
+
+  useEffect(() => {
+    const fetchBlockedUsers = async () => {
+      try {
+        const token = getCookie('token')
+        if (!token) return
+        const apiUrl = process.env.NEXT_PUBLIC_API_URL
+        const response = await fetch(`${apiUrl}/api/blocks/blocked`, {
+          headers: { Authorization: `Bearer ${token}` }
+        })
+        if (response.ok) {
+          setBlockedUsers(await response.json())
+        }
+      } catch {
+        /* non-critical */
+      } finally {
+        setBlockedLoading(false)
+      }
+    }
+    fetchBlockedUsers()
+  }, [])
+
+  const handleUnblock = async (userId: number) => {
+    try {
+      setUnblockingId(userId)
+      const token = getCookie('token')
+      if (!token) return
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL
+      const response = await fetch(`${apiUrl}/api/blocks/${userId}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` }
+      })
+      if (!response.ok) {
+        const data = await response.json()
+        toast.error(data.error || 'Failed to unblock user')
+        return
+      }
+      setBlockedUsers((prev) => prev.filter((u) => u.id !== userId))
+      toast.success('User unblocked')
+    } catch {
+      toast.error('Network error')
+    } finally {
+      setUnblockingId(null)
+    }
+  }
 
   const handleEmailUpdate = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -169,6 +226,51 @@ export default function SettingsPage() {
                 >
                   Go to Password Reset
                 </button>
+              </section>
+
+              <section className="border border-gray-200 rounded-lg p-4">
+                <h2 className="text-lg font-semibold text-black mb-4">Blocked Accounts</h2>
+                {blockedLoading && <p className="text-gray-500 text-sm">Loading...</p>}
+                {!blockedLoading && blockedUsers.length === 0 && (
+                  <p className="text-gray-500 text-sm">No blocked users.</p>
+                )}
+                {!blockedLoading && blockedUsers.length > 0 && (
+                  <ul className="divide-y divide-gray-100">
+                    {blockedUsers.map((user) => (
+                      <li key={user.id} className="flex items-center justify-between py-3">
+                        <button
+                          type="button"
+                          onClick={() => router.push(`/user/${user.id}`)}
+                          className="flex items-center gap-3 hover:opacity-80"
+                        >
+                          {user.icon_url ? (
+                            <img
+                              src={user.icon_url}
+                              alt={user.username}
+                              className="w-10 h-10 rounded-full object-cover"
+                            />
+                          ) : (
+                            <div className="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center text-gray-500 font-semibold">
+                              {user.first_name?.[0]?.toUpperCase() || '?'}
+                            </div>
+                          )}
+                          <div className="text-left">
+                            <p className="text-sm font-medium text-black">{user.first_name} {user.last_name}</p>
+                            <p className="text-xs text-gray-500">@{user.username}</p>
+                          </div>
+                        </button>
+                        <button
+                          type="button"
+                          disabled={unblockingId === user.id}
+                          onClick={() => handleUnblock(user.id)}
+                          className="text-sm text-red-600 border border-red-300 px-3 py-1 rounded-md hover:bg-red-50 disabled:opacity-50"
+                        >
+                          {unblockingId === user.id ? 'Unblocking...' : 'Unblock'}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </section>
             </>
           )}


### PR DESCRIPTION
## Summary
Adds discoverable UI for blocked accounts and likes, backed by existing authenticated APIs. Block and like list endpoints now return joined user fields (username, names, avatar) so the client can render lists without extra per-user requests

## Screen Shot
<img width="615" height="284" alt="スクリーンショット 2026-04-06 22 45 47" src="https://github.com/user-attachments/assets/0593444c-fc80-48f9-9343-9f13ea56727d" />

<img width="578" height="217" alt="スクリーンショット 2026-04-06 22 45 55" src="https://github.com/user-attachments/assets/ec565fe4-3873-4764-ab10-d754f9e27870" />

## Related Issue
Closes #110 