### PR TITLE
[FEATURE] Improve fame rating fix and fix few bugs

### DIFF
--- a/backend/src/database/seed.ts
+++ b/backend/src/database/seed.ts
@@ -336,10 +336,10 @@ export const assignTagsToUser = async (userId: number, tagMap: Map<string, numbe
 const seedInteractions = async (userIds: number[]) => {
   if (userIds.length < 2) return
 
-  // Only seed if the notifications table is empty
-  const countRes = await pool.query('SELECT COUNT(*) FROM notifications')
+  // Only seed if the likes table is empty (domain-level guard)
+  const countRes = await pool.query('SELECT COUNT(*) FROM likes')
   if (parseInt(countRes.rows[0].count, 10) > 0) {
-    console.log('ℹ️  Notifications already exist, skipping interaction seeding')
+    console.log('ℹ️  Likes already exist, skipping interaction seeding')
     return
   }
 
@@ -398,22 +398,47 @@ const seedInteractions = async (userIds: number[]) => {
       if (likerSet.has(reverseKey)) {
         // Mutual like → MATCH
         matchedPairs.add(pairKey)
-        const fakeConvId = Math.min(userId, targetId) * 100000 + Math.max(userId, targetId)
+        const u1 = Math.min(userId, targetId)
+        const u2 = Math.max(userId, targetId)
 
+        // 1. Seed likes domain table (both directions)
+        await pool.query(
+          `INSERT INTO likes (liker_id, liked_id) VALUES ($1, $2), ($2, $1) ON CONFLICT DO NOTHING`,
+          [u1, u2]
+        )
+
+        // 2. Seed conversations domain table; upsert ensures we always get the id back
+        const convRes = await pool.query(
+          `INSERT INTO conversations (user1_id, user2_id)
+           VALUES ($1, $2)
+           ON CONFLICT (user1_id, user2_id) DO UPDATE SET user1_id = EXCLUDED.user1_id
+           RETURNING id`,
+          [u1, u2]
+        )
+        const convId: number = convRes.rows[0].id
+
+        // 3. Derive MATCH notifications from the real conversation id
         await pool.query(
           `INSERT INTO notifications (user_id, actor_id, type, reference_id, created_at)
            VALUES ($1, $2, 'MATCH', $3, $4)
            ON CONFLICT DO NOTHING`,
-          [userId, targetId, fakeConvId, dateAgo]
+          [userId, targetId, convId, dateAgo]
         )
         await pool.query(
           `INSERT INTO notifications (user_id, actor_id, type, reference_id, created_at)
            VALUES ($1, $2, 'MATCH', $3, $4)
            ON CONFLICT DO NOTHING`,
-          [targetId, userId, fakeConvId, dateAgo]
+          [targetId, userId, convId, dateAgo]
         )
       } else {
-        // One-sided like → targetId receives the notification
+        // One-sided like
+        // 1. Seed likes domain table
+        await pool.query(
+          `INSERT INTO likes (liker_id, liked_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+          [userId, targetId]
+        )
+
+        // 2. Derive LIKE notification
         await pool.query(
           `INSERT INTO notifications (user_id, actor_id, type, reference_id, created_at)
            VALUES ($1, $2, 'LIKE', $3, $4)
@@ -486,30 +511,21 @@ export const seedTestUsers = async () => {
       generateFakerUser()
     )
 
-    // Combine existing test users with faker-generated users
-    const allUsers = [...testUsers, ...fakerUsers]
     console.log(
-      `📊 Total users to seed: ${allUsers.length} (${testUsers.length} test users + ${fakerUsers.length} faker users)`
+      `📊 Total users to seed: ${testUsers.length + fakerUsers.length} (${testUsers.length} test users + ${fakerUsers.length} faker users)`
     )
 
-    for (const userData of allUsers) {
-      // Check if user already exists
+    const insertUser = async (userData: TestUser): Promise<number | null> => {
       const existingUser = await pool.query(
         'SELECT id FROM users WHERE email = $1 OR username = $2',
         [userData.email, userData.username]
       )
-
       if (existingUser.rows.length > 0) {
         console.log(`⏭️  User ${userData.email} already exists, skipping...`)
-        continue
+        return null
       }
 
-      // Hash password
       const password_hash = await bcrypt.hash(userData.password, 10)
-
-      // Insert user
-      // NOTE: Database schema must include latitude and longitude columns for this to work
-      // Add to users table: latitude DOUBLE PRECISION, longitude DOUBLE PRECISION
       const query = `
         INSERT INTO users (
           email, password_hash, username, first_name, last_name,
@@ -533,20 +549,29 @@ export const seedTestUsers = async () => {
         userData.icon_url || null,
         userData.photo_urls || null
       ]
-
       const result = await pool.query(query, values)
-      const userId = result.rows[0].id
       console.log(`✅ Created test user: ${result.rows[0].email} (${result.rows[0].username})`)
-
-      // Assign tags to the user
-      await assignTagsToUser(userId, tagMap)
+      return result.rows[0].id
     }
 
-    // Seed interactions so fame ratings have meaningful values after refresh
-    const allUserIds = (await pool.query('SELECT id FROM users')).rows.map(
-      (r: { id: number }) => r.id
-    )
-    await seedInteractions(allUserIds)
+    // Seed fixed test users (excluded from random interaction generation)
+    for (const userData of testUsers) {
+      const userId = await insertUser(userData)
+      if (userId) await assignTagsToUser(userId, tagMap)
+    }
+
+    // Seed faker users and collect their IDs for interaction seeding
+    const fakerUserIds: number[] = []
+    for (const userData of fakerUsers) {
+      const userId = await insertUser(userData)
+      if (userId) {
+        await assignTagsToUser(userId, tagMap)
+        fakerUserIds.push(userId)
+      }
+    }
+
+    // Seed interactions only among faker users so test accounts stay in a known state
+    await seedInteractions(fakerUserIds)
 
     console.log('✅ Test user seeding completed!')
   } catch (err: any) {

--- a/backend/src/database/seed.ts
+++ b/backend/src/database/seed.ts
@@ -333,6 +333,131 @@ export const assignTagsToUser = async (userId: number, tagMap: Map<string, numbe
   }
 }
 
+const seedInteractions = async (userIds: number[]) => {
+  if (userIds.length < 2) return
+
+  // Only seed if the notifications table is empty
+  const countRes = await pool.query('SELECT COUNT(*) FROM notifications')
+  if (parseInt(countRes.rows[0].count, 10) > 0) {
+    console.log('ℹ️  Notifications already exist, skipping interaction seeding')
+    return
+  }
+
+  console.log('🌱 Seeding fake interactions for fame ratings...')
+
+  const randomDate = (minDaysAgo: number, maxDaysAgo: number): Date => {
+    const daysAgo = faker.number.int({ min: minDaysAgo, max: maxDaysAgo })
+    const d = new Date()
+    d.setDate(d.getDate() - daysAgo)
+    return d
+  }
+
+  // --- VIEWs ---
+  // (user_id=viewee, actor_id=viewer, reference_id=viewer)
+  const insertedViews = new Set<string>()
+  for (const userId of userIds) {
+    const others = userIds.filter((id) => id !== userId)
+    const count = faker.number.int({ min: 3, max: Math.min(25, others.length) })
+    const viewers = faker.helpers.arrayElements(others, count)
+
+    for (const actorId of viewers) {
+      const key = `${userId}-${actorId}`
+      if (insertedViews.has(key)) continue
+      insertedViews.add(key)
+
+      await pool.query(
+        `INSERT INTO notifications (user_id, actor_id, type, reference_id, created_at)
+         VALUES ($1, $2, 'VIEW', $3, $4)
+         ON CONFLICT DO NOTHING`,
+        [userId, actorId, actorId, randomDate(0, 365)]
+      )
+    }
+  }
+
+  // --- LIKEs and MATCHes ---
+  // (user_id=liked, actor_id=liker, reference_id=liker for LIKEs)
+  // (user_id=either, actor_id=other, reference_id=fakeConvId for MATCHes)
+  const likerSet = new Set<string>() // "likerId->likedId" already inserted
+  const matchedPairs = new Set<string>() // "minId-maxId" already matched
+
+  for (const userId of userIds) {
+    const others = userIds.filter((id) => id !== userId)
+    const count = faker.number.int({ min: 1, max: Math.min(10, others.length) })
+    const targets = faker.helpers.arrayElements(others, count)
+
+    for (const targetId of targets) {
+      const likeKey = `${userId}->${targetId}`
+      const reverseKey = `${targetId}->${userId}`
+      const pairKey = `${Math.min(userId, targetId)}-${Math.max(userId, targetId)}`
+
+      if (likerSet.has(likeKey) || matchedPairs.has(pairKey)) continue
+
+      const dateAgo = randomDate(0, 180)
+      likerSet.add(likeKey)
+
+      if (likerSet.has(reverseKey)) {
+        // Mutual like → MATCH
+        matchedPairs.add(pairKey)
+        const fakeConvId = Math.min(userId, targetId) * 100000 + Math.max(userId, targetId)
+
+        await pool.query(
+          `INSERT INTO notifications (user_id, actor_id, type, reference_id, created_at)
+           VALUES ($1, $2, 'MATCH', $3, $4)
+           ON CONFLICT DO NOTHING`,
+          [userId, targetId, fakeConvId, dateAgo]
+        )
+        await pool.query(
+          `INSERT INTO notifications (user_id, actor_id, type, reference_id, created_at)
+           VALUES ($1, $2, 'MATCH', $3, $4)
+           ON CONFLICT DO NOTHING`,
+          [targetId, userId, fakeConvId, dateAgo]
+        )
+      } else {
+        // One-sided like → targetId receives the notification
+        await pool.query(
+          `INSERT INTO notifications (user_id, actor_id, type, reference_id, created_at)
+           VALUES ($1, $2, 'LIKE', $3, $4)
+           ON CONFLICT DO NOTHING`,
+          [targetId, userId, userId, dateAgo]
+        )
+      }
+    }
+  }
+
+  // --- UNLIKEs (small subset of users) ---
+  // (user_id=unliked, actor_id=unliker, reference_id=unliker)
+  const unlikedSet = new Set<string>()
+  const unlikeCandidates = faker.helpers.arrayElements(userIds, Math.min(15, userIds.length))
+
+  for (const userId of unlikeCandidates) {
+    const others = userIds.filter(
+      (id) =>
+        id !== userId &&
+        !matchedPairs.has(`${Math.min(userId, id)}-${Math.max(userId, id)}`)
+    )
+    if (others.length === 0) continue
+    const count = faker.number.int({ min: 0, max: Math.min(3, others.length) })
+    const targets = faker.helpers.arrayElements(others, count)
+
+    for (const actorId of targets) {
+      const key = `${userId}-${actorId}`
+      if (unlikedSet.has(key)) continue
+      unlikedSet.add(key)
+
+      await pool.query(
+        `INSERT INTO notifications (user_id, actor_id, type, reference_id, created_at)
+         VALUES ($1, $2, 'UNLIKE', $3, $4)
+         ON CONFLICT DO NOTHING`,
+        [userId, actorId, actorId, randomDate(0, 90)]
+      )
+    }
+  }
+
+  console.log(
+    `✅ Seeded interactions: ${insertedViews.size} views, ${likerSet.size} likes/matches, ${unlikedSet.size} unlikes`
+  )
+}
+
 export const seedTestUsers = async () => {
   // Only seed if SEED_TEST_USERS environment variable is set
   if (process.env.SEED_TEST_USERS !== 'true') {
@@ -416,6 +541,12 @@ export const seedTestUsers = async () => {
       // Assign tags to the user
       await assignTagsToUser(userId, tagMap)
     }
+
+    // Seed interactions so fame ratings have meaningful values after refresh
+    const allUserIds = (await pool.query('SELECT id FROM users')).rows.map(
+      (r: { id: number }) => r.id
+    )
+    await seedInteractions(allUserIds)
 
     console.log('✅ Test user seeding completed!')
   } catch (err: any) {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,6 +4,7 @@ import http from 'http';
 import { Server as SocketServer } from 'socket.io';
 
 import { initDB } from './database/init.js';
+import { fameRatingService } from './services/fameRating.service.js';
 import { seedTestUsers } from './database/seed.js';
 import authRoutes from './routes/auth.routes.js';
 import uploadRoutes from './routes/upload.routes.js';
@@ -63,6 +64,11 @@ initDB()
     console.log("🟡 Seeding test users...");
     await seedTestUsers();
     console.log("🟢 Test users seeded");
+
+    console.log("🟡 Computing initial fame ratings...");
+    await fameRatingService.refresh();
+    fameRatingService.scheduleRefresh();
+    console.log("🟢 Fame ratings ready (refreshes every hour)");
 
     console.log(`🟡 Starting server on port ${port}...`);
     server.listen(port, () => {

--- a/backend/src/repositories/user.repository.ts
+++ b/backend/src/repositories/user.repository.ts
@@ -99,14 +99,17 @@ export const userRepository = {
         u.is_online,
         u.last_seen_at,
 
-        -- fame rating based on common tags
-        20 * (
-          SELECT COUNT(*)
-          FROM user_tags ut
-          WHERE ut.user_id = u.id
-            AND ut.tag_id IN (
-              SELECT tag_id FROM user_tags WHERE user_id = $2
-            )
+        -- fame rating
+        LEAST(
+          100,
+          (
+            SELECT
+              COUNT(*) FILTER (WHERE n.type = 'LIKE') * 5 +
+              COUNT(*) FILTER (WHERE n.type = 'VIEW') * 1 +
+              COUNT(*) FILTER (WHERE n.type = 'MATCH') * 10
+            FROM notifications n
+            WHERE n.user_id = u.id
+          )
         ) AS fame_rating,
 
         -- distance from current user
@@ -393,14 +396,16 @@ export const userRepository = {
             cos(radians(u.longitude) - radians(me.longitude)) +
             sin(radians(me.latitude)) * sin(radians(u.latitude))
           ) AS distance,
-          20 * (
-            SELECT COUNT(*)
-            FROM tags t
-            JOIN user_tags ut ON ut.tag_id = t.id
-            WHERE ut.user_id = u.id
-              AND ut.tag_id IN (
-                SELECT tag_id FROM user_tags WHERE user_id = $1
-              )
+          LEAST(
+            100,
+            (
+              SELECT
+                COUNT(*) FILTER (WHERE n.type = 'LIKE') * 5 +
+                COUNT(*) FILTER (WHERE n.type = 'VIEW') * 1 +
+                COUNT(*) FILTER (WHERE n.type = 'MATCH') * 10
+              FROM notifications n
+              WHERE n.user_id = u.id
+            )
           ) AS fame_rating,
           (
             SELECT json_agg(t.name)

--- a/backend/src/repositories/user.repository.ts
+++ b/backend/src/repositories/user.repository.ts
@@ -96,21 +96,9 @@ export const userRepository = {
         u.longitude,
         u.icon_url,
         u.photo_urls,
+        u.fame_rating,
         u.is_online,
         u.last_seen_at,
-
-        -- fame rating
-        LEAST(
-          100,
-          (
-            SELECT
-              COUNT(*) FILTER (WHERE n.type = 'LIKE') * 5 +
-              COUNT(*) FILTER (WHERE n.type = 'VIEW') * 1 +
-              COUNT(*) FILTER (WHERE n.type = 'MATCH') * 10
-            FROM notifications n
-            WHERE n.user_id = u.id
-          )
-        ) AS fame_rating,
 
         -- distance from current user
         6371 * acos(
@@ -127,7 +115,6 @@ export const userRepository = {
           AND
           (u.id != me.id)
         ) AS can_like
-
 
       FROM users u
       JOIN users me ON me.id = $2
@@ -370,7 +357,7 @@ export const userRepository = {
         orderByClause = `ORDER BY ru.fame_rating ${sortOrder}, ru.distance ASC`
         break
       case 'tags':
-        orderByClause = `ORDER BY ru.fame_rating ${sortOrder}, ru.distance ASC`
+        orderByClause = `ORDER BY COALESCE(json_array_length(ru.common_tags), 0) ${sortOrder}, ru.distance ASC`
         break
       case 'distance':
       default:
@@ -379,7 +366,7 @@ export const userRepository = {
     }
 
     const baseQuery = `
-      WITH ranked_users AS (
+      WITH base_users AS (
         SELECT
           u.id,
           u.username,
@@ -391,22 +378,12 @@ export const userRepository = {
           u.location,
           u.icon_url,
           u.photo_urls[1] AS photo_url,
+          u.fame_rating,
           6371 * acos(
             cos(radians(me.latitude)) * cos(radians(u.latitude)) *
             cos(radians(u.longitude) - radians(me.longitude)) +
             sin(radians(me.latitude)) * sin(radians(u.latitude))
           ) AS distance,
-          LEAST(
-            100,
-            (
-              SELECT
-                COUNT(*) FILTER (WHERE n.type = 'LIKE') * 5 +
-                COUNT(*) FILTER (WHERE n.type = 'VIEW') * 1 +
-                COUNT(*) FILTER (WHERE n.type = 'MATCH') * 10
-              FROM notifications n
-              WHERE n.user_id = u.id
-            )
-          ) AS fame_rating,
           (
             SELECT json_agg(t.name)
             FROM tags t
@@ -423,7 +400,7 @@ export const userRepository = {
     const searchQuery = `
       ${baseQuery}
       SELECT ru.*
-      FROM ranked_users ru
+      FROM base_users ru
       JOIN users me ON me.id = $1
       WHERE ${whereConditions}
       ${orderByClause}
@@ -435,7 +412,7 @@ export const userRepository = {
     const countQuery = `
       ${baseQuery}
       SELECT COUNT(*) as total
-      FROM ranked_users ru
+      FROM base_users ru
       JOIN users me ON me.id = $1
       WHERE ${whereConditions}
     `

--- a/backend/src/services/block.service.ts
+++ b/backend/src/services/block.service.ts
@@ -3,6 +3,7 @@ import { likeRepository } from '../repositories/like.repository.js';
 import { conversationRepository } from '../repositories/conversation.repository.js';
 import { reportRepository } from '../repositories/report.repository.js';
 import { notificationService } from './notification.service.js';
+import { fameRatingService } from './fameRating.service.js';
 
 export const blockService = {
   blockUser: async (blockerId: number, blockedId: number) => {
@@ -35,7 +36,13 @@ export const blockService = {
       notificationService.deleteNotification(blockedId, blockerId, "MATCH"),
       notificationService.deleteNotification(blockerId, blockedId, "VIEW"),
       notificationService.deleteNotification(blockedId, blockerId, "VIEW"),
+      notificationService.deleteNotification(blockerId, blockedId, "UNLIKE"),
+      notificationService.deleteNotification(blockedId, blockerId, "UNLIKE"),
     ]);
+
+    fameRatingService.refresh().catch(err =>
+      console.error('❌ Fame rating refresh failed after block:', err)
+    )
 
     return {
       success: true,

--- a/backend/src/services/fameRating.service.ts
+++ b/backend/src/services/fameRating.service.ts
@@ -1,0 +1,76 @@
+import pool from '../database/init.js'
+
+export const fameRatingService = {
+  refresh: async (): Promise<void> => {
+    const query = `
+      WITH raw_scores AS (
+        SELECT
+          u.id AS user_id,
+          GREATEST(0,
+            COALESCE((
+              SELECT SUM(
+                CASE n.type
+                  WHEN 'MATCH' THEN
+                    CASE
+                      WHEN n.created_at >= NOW() - INTERVAL '30 days' THEN 10.0
+                      WHEN n.created_at >= NOW() - INTERVAL '90 days' THEN 5.0
+                      ELSE 2.0
+                    END
+                  WHEN 'LIKE' THEN
+                    CASE WHEN NOT EXISTS (
+                      SELECT 1 FROM notifications m
+                      WHERE m.user_id = u.id AND m.actor_id = n.actor_id AND m.type = 'MATCH'
+                    ) THEN
+                      CASE
+                        WHEN n.created_at >= NOW() - INTERVAL '30 days' THEN 7.0
+                        WHEN n.created_at >= NOW() - INTERVAL '90 days' THEN 3.5
+                        ELSE 1.4
+                      END
+                    ELSE 0 END
+                  WHEN 'VIEW' THEN
+                    CASE
+                      WHEN n.created_at >= NOW() - INTERVAL '30 days' THEN 1.0
+                      WHEN n.created_at >= NOW() - INTERVAL '90 days' THEN 0.5
+                      ELSE 0.2
+                    END
+                  WHEN 'UNLIKE' THEN
+                    CASE
+                      WHEN n.created_at >= NOW() - INTERVAL '30 days' THEN -3.0
+                      WHEN n.created_at >= NOW() - INTERVAL '90 days' THEN -1.5
+                      ELSE -0.6
+                    END
+                  ELSE 0
+                END
+              )
+              FROM notifications n
+              WHERE n.user_id = u.id
+            ), 0)
+            - (SELECT COUNT(*) FROM blocks   WHERE blocked_id  = u.id) * 5
+            - (SELECT COUNT(*) FROM reports  WHERE reported_id = u.id) * 15
+            + CASE WHEN array_length(u.photo_urls, 1) >= 2 THEN 5 ELSE 0 END
+            + CASE WHEN (SELECT COUNT(*) FROM user_tags WHERE user_id = u.id) >= 3 THEN 5 ELSE 0 END
+          ) AS raw_score
+        FROM users u
+      ),
+      percentiles AS (
+        SELECT
+          user_id,
+          ROUND(PERCENT_RANK() OVER (ORDER BY raw_score) * 100)::int AS fame_rating
+        FROM raw_scores
+      )
+      UPDATE users u
+      SET fame_rating = p.fame_rating
+      FROM percentiles p
+      WHERE u.id = p.user_id
+    `
+    await pool.query(query)
+  },
+
+  scheduleRefresh: (intervalMs = 3_600_000): NodeJS.Timeout => {
+    return setInterval(() => {
+      fameRatingService.refresh().catch(err =>
+        console.error('❌ Scheduled fame rating refresh failed:', err)
+      )
+    }, intervalMs)
+  }
+}

--- a/backend/src/services/like.service.ts
+++ b/backend/src/services/like.service.ts
@@ -1,6 +1,7 @@
 import { likeRepository } from '../repositories/like.repository.js';
 import { conversationRepository } from '../repositories/conversation.repository.js';
 import { notificationService } from './notification.service.js';
+import { fameRatingService } from './fameRating.service.js';
 import { HttpError } from '../errors/HttpError.js';
 import { blockRepository } from '../repositories/block.repository.js';
 import { reportRepository } from '../repositories/report.repository.js';
@@ -44,6 +45,9 @@ export const likeService = {
     // Create the like
     await likeRepository.createLike(likerId, likedId);
 
+    // Clear any stale UNLIKE from a previous unlike cycle
+    await notificationService.deleteNotification(likedId, likerId, "UNLIKE");
+
     // Check for mutual like (match)
     const isMatch = await likeRepository.checkMutualLike(likerId, likedId);
     let conversationId: number | null = null;
@@ -52,6 +56,9 @@ export const likeService = {
       // Send LIKE notification to the liked user
       await notificationService.createNotification(likedId, likerId, "LIKE", likerId);
     } else {
+      // Clear the old LIKE notification (now superseded by MATCH)
+      await notificationService.deleteNotification(likerId, likedId, "LIKE");
+
       const user1 = Math.min(likerId, likedId);
       const user2 = Math.max(likerId, likedId);
 
@@ -69,6 +76,10 @@ export const likeService = {
       await notificationService.createNotification(likedId, likerId, "MATCH", conversation.id);
     }
 
+
+    fameRatingService.refresh().catch(err =>
+      console.error('❌ Fame rating refresh failed after like:', err)
+    )
 
     return {
       success: true,
@@ -90,9 +101,14 @@ export const likeService = {
     await notificationService.deleteNotification(likedId, likerId, "LIKE");
     await notificationService.deleteNotification(likerId, likedId, "MATCH");
     await notificationService.deleteNotification(likedId, likerId, "MATCH");
+    await notificationService.createNotification(likedId, likerId, "UNLIKE", likerId);
     if (wasMatch) {
       await conversationRepository.removeConversation(likerId, likedId);
     }
+
+    fameRatingService.refresh().catch(err =>
+      console.error('❌ Fame rating refresh failed after unlike:', err)
+    )
 
     return {
       success: true,

--- a/backend/src/services/like.service.ts
+++ b/backend/src/services/like.service.ts
@@ -45,8 +45,9 @@ export const likeService = {
     // Create the like
     await likeRepository.createLike(likerId, likedId);
 
-    // Clear any stale UNLIKE from a previous unlike cycle
+    // Clear any stale UNLIKE from a previous unlike cycle (both directions)
     await notificationService.deleteNotification(likedId, likerId, "UNLIKE");
+    await notificationService.deleteNotification(likerId, likedId, "UNLIKE");
 
     // Check for mutual like (match)
     const isMatch = await likeRepository.checkMutualLike(likerId, likedId);
@@ -101,9 +102,10 @@ export const likeService = {
     await notificationService.deleteNotification(likedId, likerId, "LIKE");
     await notificationService.deleteNotification(likerId, likedId, "MATCH");
     await notificationService.deleteNotification(likedId, likerId, "MATCH");
-    await notificationService.createNotification(likedId, likerId, "UNLIKE", likerId);
     if (wasMatch) {
+      await likeRepository.deleteLike(likedId, likerId);
       await conversationRepository.removeConversation(likerId, likedId);
+      await notificationService.createNotification(likedId, likerId, "UNLIKE", likerId);
     }
 
     fameRatingService.refresh().catch(err =>

--- a/backend/src/services/notification.service.ts
+++ b/backend/src/services/notification.service.ts
@@ -29,7 +29,7 @@ export const notificationService = {
     deleteNotification: async (userId: number, actorId: number, type: NotificationType ) => {
         const result = await notificationRepository.deleteNotification(userId, actorId, type);
         if (result) {
-            notificationEmitter.emit('notification:deleted', { userId });
+            notificationEmitter.emit('notification:deleted', { userId, notification: { userId, actorId, type } });
         }
         return result;
     },

--- a/backend/src/services/report.service.ts
+++ b/backend/src/services/report.service.ts
@@ -3,6 +3,7 @@ import { likeRepository } from '../repositories/like.repository.js';
 import { conversationRepository } from '../repositories/conversation.repository.js';
 import { blockRepository } from '../repositories/block.repository.js';
 import { notificationService } from './notification.service.js';
+import { fameRatingService } from './fameRating.service.js';
 
 
 const VALID_REASONS: ReportReason[] = ['FAKE_ACCOUNT', 'SPAM', 'HARASSMENT', 'INAPPROPRIATE', 'OTHER'];
@@ -42,6 +43,10 @@ export const reportService = {
       notificationService.deleteNotification(reporterId, reportedId, "VIEW"),
       notificationService.deleteNotification(reportedId, reporterId, "VIEW"),
     ]);
+
+    fameRatingService.refresh().catch(err =>
+      console.error('❌ Fame rating refresh failed after report:', err)
+    )
 
     return {
       success: true,

--- a/backend/src/socket/notification.handlers.ts
+++ b/backend/src/socket/notification.handlers.ts
@@ -12,10 +12,11 @@ export function setupNotificationSocket(io: Server): void {
             console.error('Failed to emit notification events:', err);
         }
     });
-    notificationEmitter.on('notification:deleted', async ({ userId }: { userId: number}) => {
+    notificationEmitter.on('notification:deleted', async ({ userId, notification }: { userId: number; notification: any }) => {
         try {
             const count = await notificationRepository.getUnreadCount(userId);
             io.to(`user:${userId}`).emit('unreadNotificationCount', { count });
+            io.to(`user:${userId}`).emit('removeNotification', notification);
         } catch (err) {
             console.error('Failed to emit unreadNotificationCount:', err);
         }

--- a/frontend/src/app/notifications/NotificationsClient.tsx
+++ b/frontend/src/app/notifications/NotificationsClient.tsx
@@ -54,7 +54,10 @@ export default function NotificationsClient() {
     const onNewNotification = (notification: Notification) => {
       setNotifications(prev => {
         if (prev.some(n => n.id === notification.id)) return prev
-        return [notification, ...prev]
+        const filtered = prev.filter(
+          n => !(n.actor_id === notification.actor_id && isSuperseded(n.type, notification.type))
+        )
+        return [notification, ...filtered]
       })
     }
     socket.on('newNotification', onNewNotification)
@@ -145,6 +148,13 @@ export default function NotificationsClient() {
       </div>
     </div>
   )
+}
+
+function isSuperseded(existing: Notification['type'], incoming: Notification['type']): boolean {
+  if (incoming === 'MATCH' && (existing === 'LIKE' || existing === 'UNLIKE')) return true
+  if (incoming === 'UNLIKE' && existing === 'MATCH') return true
+  if (incoming === 'LIKE' && existing === 'UNLIKE') return true
+  return false
 }
 
 function renderNotificationText(n: Notification) {

--- a/frontend/src/app/notifications/NotificationsClient.tsx
+++ b/frontend/src/app/notifications/NotificationsClient.tsx
@@ -60,9 +60,14 @@ export default function NotificationsClient() {
         return [notification, ...filtered]
       })
     }
+    const onRemoveNotification = ({ actorId, type }: { userId: number; actorId: number; type: Notification['type'] }) => {
+      setNotifications(prev => prev.filter(n => !(n.actor_id === actorId && n.type === type)))
+    }
     socket.on('newNotification', onNewNotification)
+    socket.on('removeNotification', onRemoveNotification)
     return () => {
       socket.off('newNotification', onNewNotification)
+      socket.off('removeNotification', onRemoveNotification)
     }
   }, [])
 

--- a/frontend/src/app/notifications/NotificationsClient.tsx
+++ b/frontend/src/app/notifications/NotificationsClient.tsx
@@ -47,7 +47,7 @@ export default function NotificationsClient() {
       }
     }
     fetchNotifications()
-  }, [])
+  }, [router])
 
   useEffect(() => {
     const socket = getSocket()


### PR DESCRIPTION
## feat/improve-fame-rating

### Overview

This PR reworks the fame rating system and fixes several notification bugs discovered
during the process.

---

### 1. Fame Rating — Complete Rework

#### What is Fame Rating?

Fame rating is a **0–100 score** reflecting how popular a user is relative to everyone
else on the platform. It is used for search filtering and sorting.

#### Old implementation (removed)

Fame rating was computed **on every request** by scanning the entire notifications table
for all users — O(N × notifications) per profile view or search. The formula was also flat
and simplistic:
`LIKE × 5 + VIEW × 1 + MATCH × 10 (capped at 100)`


#### New implementation

Fame rating is now **stored in `users.fame_rating`** and refreshed periodically.
Reads are O(1).

**New scoring formula with time-decay:**

| Signal | < 30 days | 30–90 days | Older |
|---|---|---|---|
| MATCH | +10 | +5 | +2 |
| LIKE (no match) | +7 | +3.5 | +1.4 |
| VIEW | +1 | +0.5 | +0.2 |
| UNLIKE | −3 | −1.5 | −0.6 |
| Being blocked | −5 (flat) | | |
| Being reported | −15 (flat) | | |
| ≥ 2 extra photos | +5 bonus | | |
| ≥ 3 tags | +5 bonus | | |

Raw score is clamped to 0, then `PERCENT_RANK()` converts it to a 0–100 percentile
across all users.

**When is it refreshed?**

| Trigger | Type |
|---|---|
| Server startup | Awaited (blocking) |
| Every hour | Background timer |
| After like / unlike | Fire-and-forget |
| After block | Fire-and-forget |
| After report | Fire-and-forget |

#### Seed data

Added `seedInteractions()` in `seed.ts` to populate the notifications table with
realistic fake VIEWs, LIKEs, MATCHes, and UNLIKEs (with timestamps spread over the
past year) so seeded users start with meaningful, distributed fame ratings instead of
all being 0. Only runs once when the notifications table is empty.

---

### 2. Notification Bug Fixes

These bugs were found while reviewing the notification system as part of the fame rating
work.

#### Bug 1 — UNLIKE notifications accumulated on repeated like/unlike cycles

`UNLIKE` notifications were inserted without a `reference_id` (= `NULL`). In PostgreSQL,
`NULL != NULL` in UNIQUE constraints, so `ON CONFLICT DO NOTHING` never fired. Each
unlike cycle inserted a new row, causing unlimited accumulation in the DB and on screen.

**Fix:** `UNLIKE` now uses `likerId` as `reference_id`, consistent with `LIKE` and `VIEW`.

#### Bug 2 — Re-liking did not clear the UNLIKE notification

After A unlikes B (UNLIKE created), if A likes B again, the UNLIKE notification was
never deleted. B kept a permanent −3 fame penalty even though A came back.

**Fix:** `likeUser` now deletes the stale UNLIKE notification before creating the new LIKE.

#### Bug 3 — Stale LIKE shown alongside MATCH in notification inbox

When A liked B first (B gets a LIKE notification), then B liked A back (match), the old
LIKE was never removed. B's inbox showed both "X liked you" and "You matched with X"
from the same person simultaneously.

**Fix:** `likeUser` now deletes the old LIKE notification when a match is detected.

#### Bug 4 — Block did not clean up UNLIKE notifications

`blockUser` cleaned LIKE, MATCH, and VIEW notifications in both directions, but not
UNLIKE. This caused a double penalty: −3 (UNLIKE) + −5 (block) on the blocked user's
fame rating.

**Fix:** Added UNLIKE cleanup in both directions to `blockUser`.

#### Bug 5 — Frontend did not remove superseded notifications on WebSocket push

When a notification was deleted in the DB (e.g. MATCH deleted on unmatch), the backend
only emitted `unreadNotificationCount` — no signal to remove the specific notification
from the displayed list. Combined with the above bugs, this caused the inbox to show
all historical match/unmatch events stacked.

**Fix:** When a `newNotification` WebSocket event arrives, the frontend now filters out
any existing notification from the same actor that is superseded by the incoming one
before prepending it to the list.

| Incoming | Removes from list |
|---|---|
| `MATCH` | stale `LIKE` or `UNLIKE` from same actor |
| `UNLIKE` | old `MATCH` from same actor |
| `LIKE` | old `UNLIKE` from same actor |

---


## Related Issue
Closes #122
Closes #113 
Closes #120
Closes #103 